### PR TITLE
feat: add upsert and return support

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -1,5 +1,10 @@
 package org.hypertrace.core.documentstore.mongo;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -97,13 +102,13 @@ public class MongoDocStoreTest {
     {
       // empty query returns all the documents
       Query query = new Query();
-      Assertions.assertEquals(6, collection.total(query));
+      assertEquals(6, collection.total(query));
     }
 
     {
       Query query = new Query();
       query.setFilter(Filter.eq("name", "Bob"));
-      Assertions.assertEquals(2, collection.total(query));
+      assertEquals(2, collection.total(query));
     }
 
     {
@@ -111,7 +116,7 @@ public class MongoDocStoreTest {
       Query query = new Query();
       query.setFilter(Filter.eq("name", "Bob"));
       query.setLimit(1);
-      Assertions.assertEquals(2, collection.total(query));
+      assertEquals(2, collection.total(query));
     }
   }
 
@@ -136,7 +141,7 @@ public class MongoDocStoreTest {
         documents.add(results.next());
       }
 
-      Assertions.assertEquals(2, documents.size());
+      assertEquals(2, documents.size());
       String persistedDocument1 = documents.get(0).toJson();
       Assertions.assertTrue(persistedDocument1.contains("foo2"));
       String persistedDocument2 = documents.get(1).toJson();
@@ -181,8 +186,43 @@ public class MongoDocStoreTest {
     node = OBJECT_MAPPER.readTree(persistedDocument);
     String newLastUpdatedtime = node.findValue(LAST_UPDATED_TIME_KEY).findValue("$date").asText();
     long newCreatedTime = node.findValue(LAST_CREATED_TIME_KEY).asLong();
-    Assertions.assertEquals(createdTime, newCreatedTime);
+    assertEquals(createdTime, newCreatedTime);
     Assertions.assertFalse(newLastUpdatedtime.equalsIgnoreCase(lastUpdatedtime));
+  }
+
+
+  @Test
+  public void testUpsertAndReturn() throws IOException {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
+    objectNode.put("foo1", "bar1");
+    Document document = new JSONDocument(objectNode);
+    Document persistedDocument = collection.upsertAndReturn(new SingleValueKey("default", "testKey"), document);
+
+    Query query = new Query();
+    query.setFilter(Filter.eq("_id", "default:testKey"));
+    // Assert upsert and search results match
+    assertEquals(collection.search(query).next(), persistedDocument);
+
+    JsonNode node = OBJECT_MAPPER.readTree(persistedDocument.toJson());
+    String lastUpdatedTime = node.findValue(LAST_UPDATED_TIME_KEY).findValue("$date").asText();
+    long createdTime = node.findValue(LAST_CREATED_TIME_KEY).asLong();
+
+    objectNode = OBJECT_MAPPER.createObjectNode();
+    objectNode.put("foo2", "bar2");
+    document = new JSONDocument(objectNode);
+
+    // Upsert again and verify that createdTime does not change, while lastUpdatedTime
+    // has changed and values have merged
+    Document updatedDocument = collection.upsertAndReturn(new SingleValueKey("default", "testKey"), document);
+    node = OBJECT_MAPPER.readTree(updatedDocument.toJson());
+    String newLastUpdatedtime = node.findValue(LAST_UPDATED_TIME_KEY).findValue("$date").asText();
+    long newCreatedTime = node.findValue(LAST_CREATED_TIME_KEY).asLong();
+    assertEquals(createdTime, newCreatedTime);
+    assertNotEquals(lastUpdatedTime, newLastUpdatedtime);
+
+    assertEquals("bar1", node.get("foo1").asText());
+    assertEquals("bar2", node.get("foo2").asText());
   }
 
   @Test
@@ -258,7 +298,7 @@ public class MongoDocStoreTest {
       results.add(dbObject);
       System.out.println(dbObject);
     }
-    Assertions.assertEquals(2, results.size());
+    assertEquals(2, results.size());
   }
 
   @Test
@@ -294,7 +334,7 @@ public class MongoDocStoreTest {
       results.add(dbObject);
       System.out.println(dbObject);
     }
-    Assertions.assertEquals(1, results.size());
+    assertEquals(1, results.size());
   }
 
   private Document createDocument(String key, String value) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -13,9 +13,18 @@ public interface Collection {
    *
    * @param key      Unique key of the document in the collection.
    * @param document Document to be upserted.
-   * @return True if this operation resulted in updation of an existing document. False, otherwise.
+   * @return True if this operation resulted in update of an existing document. False, otherwise.
    */
   boolean upsert(Key key, Document document) throws IOException;
+
+  /**
+   * Upsert (create a new doc or update if one already exists) the given document into the doc store.
+   *
+   * @param key      Unique key of the document in the collection.
+   * @param document Document to be upserted.
+   * @return Returns the updated document regardless if an update occurred
+   */
+  Document upsertAndReturn(Key key, Document document) throws IOException;
 
   /**
    * Update a sub document

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore.mongo;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -13,6 +14,7 @@ import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoServerException;
 import com.mongodb.WriteResult;
+import com.mongodb.client.model.DBCollectionFindAndModifyOptions;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,11 +29,11 @@ import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Document;
-import org.hypertrace.core.documentstore.Query;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.Key;
 import org.hypertrace.core.documentstore.OrderBy;
+import org.hypertrace.core.documentstore.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,24 +54,8 @@ public class MongoCollection implements Collection {
 
   @Override
   public boolean upsert(Key key, Document document) throws IOException {
-    String jsonString = document.toJson();
     try {
-      JsonNode jsonNode = MAPPER.readTree(jsonString);
-
-      // escape "." and "$" in field names since Mongo DB does not like them
-      JsonNode sanitizedJsonNode = recursiveClone(jsonNode, this::encodeKey);
-      BasicDBObject setObject = BasicDBObject.parse(MAPPER.writeValueAsString(sanitizedJsonNode));
-      setObject.put(ID_KEY, key.toString());
-      BasicDBObject dbObject =
-          new BasicDBObject("$set", setObject)
-              .append("$currentDate", new BasicDBObject(LAST_UPDATE_TIME, true))
-              .append("$setOnInsert", new BasicDBObject(CREATED_TIME, System.currentTimeMillis()));
-
-      // Create selection criteria from the key.
-      BasicDBObject selectionCriteria = new BasicDBObject();
-      selectionCriteria.put(ID_KEY, key.toString());
-
-      WriteResult writeResult = collection.update(selectionCriteria, dbObject, true, false);
+      WriteResult writeResult = collection.update(this.selectionCriteriaForKey(key), this.prepareUpsert(key, document), true, false);
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Write result: " + writeResult.toString());
       }
@@ -81,6 +67,30 @@ public class MongoCollection implements Collection {
     }
   }
 
+  @Override
+  public Document upsertAndReturn(Key key, Document document) throws IOException {
+    DBObject upsertResult = collection.findAndModify(this.selectionCriteriaForKey(key), new DBCollectionFindAndModifyOptions()
+    .update(this.prepareUpsert(key, document))
+    .upsert(true)
+    .returnNew(true));
+
+    return this.dbObjectToDocument(upsertResult);
+  }
+
+  private BasicDBObject prepareUpsert(Key key, Document document) throws JsonProcessingException {
+    String jsonString = document.toJson();
+    JsonNode jsonNode = MAPPER.readTree(jsonString);
+
+    // escape "." and "$" in field names since Mongo DB does not like them
+    JsonNode sanitizedJsonNode = recursiveClone(jsonNode, this::encodeKey);
+    BasicDBObject setObject = BasicDBObject.parse(MAPPER.writeValueAsString(sanitizedJsonNode));
+    setObject.put(ID_KEY, key.toString());
+    return new BasicDBObject("$set", setObject)
+        .append("$currentDate", new BasicDBObject(LAST_UPDATE_TIME, true))
+        .append("$setOnInsert", new BasicDBObject(CREATED_TIME, System.currentTimeMillis()));
+  }
+
+  @Override
   public boolean updateSubDoc(Key key, String subDocPath, Document subDocument) {
     String jsonString = subDocument.toJson();
     try {
@@ -93,11 +103,7 @@ public class MongoCollection implements Collection {
               subDocPath, BasicDBObject.parse(MAPPER.writeValueAsString(sanitizedJsonNode)));
       BasicDBObject setObject = new BasicDBObject("$set", dbObject);
 
-      // Create selection criteria from the key.
-      BasicDBObject selectionCriteria = new BasicDBObject();
-      selectionCriteria.put(ID_KEY, key.toString());
-
-      WriteResult writeResult = collection.update(selectionCriteria, setObject, false, false);
+      WriteResult writeResult = collection.update(selectionCriteriaForKey(key), setObject, false, false);
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Write result: " + writeResult.toString());
       }
@@ -182,39 +188,14 @@ public class MongoCollection implements Collection {
 
       @Override
       public Document next() {
-        DBObject next = dbCursor.next();
-        try {
-          // Hack: Remove the _id field since it's an unrecognized field for Proto layer.
-          // TODO: We should rather use separate DAO classes instead of using the
-          //  DB document directly as proto message.
-          next.removeField(ID_KEY);
-          String jsonString;
-          JsonWriterSettings relaxed =
-              JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build();
-          if (next instanceof BasicDBObject) {
-            jsonString = ((BasicDBObject) next).toJson(relaxed);
-          } else {
-            LOGGER.info(
-                "Converting to bson document before converting JSON for none BasicDBObject type");
-            jsonString = org.bson.Document.parse(next.toString()).toJson(relaxed);
-          }
-          JsonNode jsonNode = MAPPER.readTree(jsonString);
-          JsonNode decodedJsonNode = recursiveClone(jsonNode, key -> decodeKey(key));
-          return new JSONDocument(decodedJsonNode);
-        } catch (IOException e) {
-          // throwing exception is not very useful here.
-          return JSONDocument.errorDocument(e.getMessage());
-        }
+        return MongoCollection.this.dbObjectToDocument(dbCursor.next());
       }
     };
   }
 
   @Override
   public boolean delete(Key key) {
-    // Create selection criteria from the key.
-    BasicDBObject selectionCriteria = new BasicDBObject();
-    selectionCriteria.put(ID_KEY, key.toString());
-    collection.remove(selectionCriteria);
+    collection.remove(this.selectionCriteriaForKey(key));
 
     // If there was no exception, the operation is successful.
     return true;
@@ -222,10 +203,9 @@ public class MongoCollection implements Collection {
 
   @Override
   public boolean deleteSubDoc(Key key, String subDocPath) {
-    BasicDBObject selectionCriteria = new BasicDBObject(ID_KEY, key.toString());
     BasicDBObject unsetObject = new BasicDBObject("$unset", new BasicDBObject(subDocPath, ""));
 
-    WriteResult writeResult = collection.update(selectionCriteria, unsetObject, false, false);
+    WriteResult writeResult = collection.update(this.selectionCriteriaForKey(key), unsetObject, false, false);
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Write result: " + writeResult.toString());
     }
@@ -354,13 +334,9 @@ public class MongoCollection implements Collection {
 
         dbObject.put(ID_KEY, key.toString());
 
-        // Create selection criteria from the key.
-        BasicDBObject selectionCriteria = new BasicDBObject();
-        selectionCriteria.put(ID_KEY, key.toString());
-
         // insert or overwrite
         bulkWriteOperation
-            .find(selectionCriteria)
+            .find(this.selectionCriteriaForKey(key))
             .upsert()
             .update(
                 new BasicDBObject("$set", dbObject)
@@ -381,5 +357,34 @@ public class MongoCollection implements Collection {
   @Override
   public void drop() {
     collection.drop();
+  }
+
+  private DBObject selectionCriteriaForKey(Key key) {
+    return new BasicDBObject(ID_KEY, key.toString());
+  }
+
+  private Document dbObjectToDocument(DBObject dbObject) {
+    try {
+      // Hack: Remove the _id field since it's an unrecognized field for Proto layer.
+      // TODO: We should rather use separate DAO classes instead of using the
+      //  DB document directly as proto message.
+      dbObject.removeField(ID_KEY);
+      String jsonString;
+      JsonWriterSettings relaxed =
+          JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build();
+      if (dbObject instanceof BasicDBObject) {
+        jsonString = ((BasicDBObject) dbObject).toJson(relaxed);
+      } else {
+        LOGGER.info(
+            "Converting to bson document before converting JSON for none BasicDBObject type");
+        jsonString = org.bson.Document.parse(dbObject.toString()).toJson(relaxed);
+      }
+      JsonNode jsonNode = MAPPER.readTree(jsonString);
+      JsonNode decodedJsonNode = recursiveClone(jsonNode, this::decodeKey);
+      return new JSONDocument(decodedJsonNode);
+    } catch (IOException e) {
+      // throwing exception is not very useful here.
+      return JSONDocument.errorDocument(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## Description
This PR adds support to atomically upsert and return the result. Existing APIs only support upserting with a boolean status of the result, forcing multiple round trips to retrieve the result. This API was added rather than updating the existing API for backwards compatibility.

This will be used by updates in entity service to streamline the behavior of the entity upsert API.

### Testing
Integration tests have been added to test the new API.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Javadoc added for the new API