### PR TITLE
fix: Retrying upserts which fails due to a known MongoDB bug.

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
   implementation("org.slf4j:slf4j-api:1.7.25")
   implementation("com.google.guava:guava-annotations:r03")
+  implementation("net.jodah:failsafe:2.4.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:2.19.0")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.6.2")


### PR DESCRIPTION
See https://jira.mongodb.org/browse/SERVER-47212

The current MongoDB servers we use have a known issue - https://jira.mongodb.org/browse/SERVER-47212
where the findAndModify operation might fail with duplicate key exception and server was supposed to
retry that but it doesn't. Since the fix isn't available in the released MongoDB versions,
we are retrying the upserts in these cases in client layer so that we avoid frequent failures in this layer.