### PR TITLE
Makes lastUpdatedTime consistent with createdTime

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -51,6 +51,7 @@ public class MongoCollection implements Collection {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoCollection.class);
   public static final String ID_KEY = "_id";
   private static final String LAST_UPDATE_TIME = "_lastUpdateTime";
+  private static final String LAST_UPDATED_TIME = "lastUpdatedTime";
   /* follow json/protobuf convention to make it deser, let's not make our life harder */
   private static final String CREATED_TIME = "createdTime";
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -131,6 +132,7 @@ public class MongoCollection implements Collection {
     JsonNode sanitizedJsonNode = recursiveClone(jsonNode, this::encodeKey);
     BasicDBObject setObject = BasicDBObject.parse(MAPPER.writeValueAsString(sanitizedJsonNode));
     setObject.put(ID_KEY, key.toString());
+    setObject.put(LAST_UPDATED_TIME, System.currentTimeMillis());
     return new BasicDBObject("$set", setObject)
         .append("$currentDate", new BasicDBObject(LAST_UPDATE_TIME, true))
         .append("$setOnInsert", new BasicDBObject(CREATED_TIME, System.currentTimeMillis()));
@@ -147,6 +149,7 @@ public class MongoCollection implements Collection {
       BasicDBObject dbObject =
           new BasicDBObject(
               subDocPath, BasicDBObject.parse(MAPPER.writeValueAsString(sanitizedJsonNode)));
+      dbObject.append(LAST_UPDATED_TIME, System.currentTimeMillis());
       BasicDBObject setObject = new BasicDBObject("$set", dbObject);
 
       UpdateResult writeResult = collection.updateOne(selectionCriteriaForKey(key), setObject,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -49,11 +49,14 @@ import org.slf4j.LoggerFactory;
 /** An implementation of the {@link Collection} interface with MongoDB as the backend */
 public class MongoCollection implements Collection {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoCollection.class);
+
+  // Fields automatically added for each document
   public static final String ID_KEY = "_id";
   private static final String LAST_UPDATE_TIME = "_lastUpdateTime";
   private static final String LAST_UPDATED_TIME = "lastUpdatedTime";
   /* follow json/protobuf convention to make it deser, let's not make our life harder */
   private static final String CREATED_TIME = "createdTime";
+  
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final int MAX_RETRY_ATTEMPTS_FOR_DUPLICATE_KEY_ISSUE = 2;
@@ -111,6 +114,10 @@ public class MongoCollection implements Collection {
     }
   }
 
+  /**
+   * Adds the following fields automatically:
+   * _id, _lastUpdateTime, lastUpdatedTime and created Time
+   */
   @Override
   public Document upsertAndReturn(Key key, Document document) throws IOException {
     BasicDBObject upsertResult = Failsafe.with(upsertRetryPolicy).get(() -> collection.findOneAndUpdate(
@@ -138,6 +145,10 @@ public class MongoCollection implements Collection {
         .append("$setOnInsert", new BasicDBObject(CREATED_TIME, System.currentTimeMillis()));
   }
 
+  /**
+   * Adds the following fields automatically:
+   * _id, _lastUpdateTime, lastUpdatedTime and created Time
+   */
   @Override
   public boolean updateSubDoc(Key key, String subDocPath, Document subDocument) {
     String jsonString = subDocument.toJson();

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
@@ -61,10 +61,4 @@ public class FilterTest {
     Assertions.assertNotNull(filter2.getChildFilters());
     Assertions.assertEquals(0, filter2.getChildFilters().length);
   }
-
-  @Test
-  public void testFilterDate() {
-    Filter filter = new Filter();
-
-  }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
@@ -61,4 +61,10 @@ public class FilterTest {
     Assertions.assertNotNull(filter2.getChildFilters());
     Assertions.assertEquals(0, filter2.getChildFilters().length);
   }
+
+  @Test
+  public void testFilterDate() {
+    Filter filter = new Filter();
+
+  }
 }


### PR DESCRIPTION
_lastUpdateTime stores the last updated timestamp in Date and has different
convention than createdTime.

field name without underscore is preferred, and long value makes it
easier for comparison with the current type support