### PR TITLE
Adding a new returnAndBulkUpsert API in the doc store.

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:2.19.0")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  integrationTestImplementation("com.github.java-json-tools:json-patch:1.13")
 }
 
 tasks.test {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -112,8 +112,8 @@ public class MongoDocStoreTest {
       String persistedDocument = documents.get(0).toJson();
       JsonNode jsonNode = OBJECT_MAPPER.reader().readTree(persistedDocument);
       Assertions.assertTrue(persistedDocument.contains("Bob"));
-      Assertions.assertTrue(jsonNode.findValue("createdTime").asLong(0) > now);
-      Assertions.assertTrue(jsonNode.findValue("lastUpdatedTime").asLong(0) > now);
+      Assertions.assertTrue(jsonNode.findValue("createdTime").asLong(0) >= now);
+      Assertions.assertTrue(jsonNode.findValue("lastUpdatedTime").asLong(0) >= now);
     }
   }
 
@@ -403,7 +403,12 @@ public class MongoDocStoreTest {
         new SingleValueKey("default", "testKey2"), createDocument("testKey2", "abc2")
     );
 
-    Iterator<Document> iterator = collection.bulkUpsertAndReturn(documentMap);
+    Iterator<Document> iterator = collection.returnAndBulkUpsert(documentMap);
+    // Initially there shouldn't be any documents.
+    Assertions.assertFalse(iterator.hasNext());
+
+    // The operation should be idempotent so go ahead and try again.
+    iterator = collection.returnAndBulkUpsert(documentMap);
     assertEquals(2, collection.count());
     List<Document> documents = new ArrayList<>();
     while (iterator.hasNext()) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -395,6 +395,28 @@ public class MongoDocStoreTest {
   }
 
   @Test
+  public void testBulkUpsertAndReturn() throws IOException {
+    datastore.createCollection(COLLECTION_NAME, null);
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    Map<Key, Document> documentMap = Map.of(
+        new SingleValueKey("default", "testKey1"), createDocument("testKey1", "abc1"),
+        new SingleValueKey("default", "testKey2"), createDocument("testKey2", "abc2")
+    );
+
+    Iterator<Document> iterator = collection.bulkUpsertAndReturn(documentMap);
+    assertEquals(2, collection.count());
+    List<Document> documents = new ArrayList<>();
+    while (iterator.hasNext()) {
+      documents.add(iterator.next());
+    }
+    assertEquals(2, documents.size());
+
+    // Delete one of the documents and test again.
+    collection.delete(new SingleValueKey("default", "testKey1"));
+    assertEquals(1, collection.count());
+  }
+
+  @Test
   public void testLike() {
     MongoClient mongoClient = MongoClients.create("mongodb://localhost:27017");
 

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jsonpatch.diff.JsonDiff;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.client.FindIterable;
@@ -22,9 +24,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Datastore;
 import org.hypertrace.core.documentstore.DatastoreProvider;
@@ -395,20 +401,24 @@ public class MongoDocStoreTest {
   }
 
   @Test
-  public void testBulkUpsertAndReturn() throws IOException {
+  public void testReturnAndBulkUpsert() throws IOException {
     datastore.createCollection(COLLECTION_NAME, null);
     Collection collection = datastore.getCollection(COLLECTION_NAME);
-    Map<Key, Document> documentMap = Map.of(
-        new SingleValueKey("default", "testKey1"), createDocument("testKey1", "abc1"),
-        new SingleValueKey("default", "testKey2"), createDocument("testKey2", "abc2")
+    Map<Key, Document> documentMapV1 = Map.of(
+        new SingleValueKey("default", "testKey1"), createDocument("id", "1", "testKey1", "abc-v1"),
+        new SingleValueKey("default", "testKey2"), createDocument("id", "2", "testKey2", "xyz-v1")
     );
 
-    Iterator<Document> iterator = collection.returnAndBulkUpsert(documentMap);
+    Iterator<Document> iterator = collection.returnAndBulkUpsert(documentMapV1);
     // Initially there shouldn't be any documents.
     Assertions.assertFalse(iterator.hasNext());
 
-    // The operation should be idempotent so go ahead and try again.
-    iterator = collection.returnAndBulkUpsert(documentMap);
+    // Add more details to the document and bulk upsert again.
+    Map<Key, Document> documentMapV2 = Map.of(
+        new SingleValueKey("default", "testKey1"), createDocument("id", "1", "testKey1", "abc-v2"),
+        new SingleValueKey("default", "testKey2"), createDocument("id", "2", "testKey2", "xyz-v2")
+    );
+    iterator = collection.returnAndBulkUpsert(documentMapV2);
     assertEquals(2, collection.count());
     List<Document> documents = new ArrayList<>();
     while (iterator.hasNext()) {
@@ -416,9 +426,46 @@ public class MongoDocStoreTest {
     }
     assertEquals(2, documents.size());
 
+    Map<String, JsonNode> expectedDocs = convertToMap(documentMapV1.values(), "id");
+    Map<String, JsonNode> actualDocs = convertToMap(documents, "id");
+
+    // Verify that the documents returned were previous copies.
+    for (Map.Entry<String, JsonNode> entry: expectedDocs.entrySet()) {
+      JsonNode expected = entry.getValue();
+      JsonNode actual = actualDocs.get(entry.getKey());
+
+      Assertions.assertNotNull(actual);
+      JsonNode patch = JsonDiff.asJson(expected, actual);
+
+      // Verify that there are only additions and "no" removals in this new node.
+      Set<String> ops = new HashSet<>();
+      patch.elements().forEachRemaining(e -> {
+        if (e.has("op")) {
+          ops.add(e.get("op").asText());
+        }
+      });
+
+      Assertions.assertTrue(ops.contains("add"));
+      Assertions.assertEquals(1, ops.size());
+    }
+
     // Delete one of the documents and test again.
     collection.delete(new SingleValueKey("default", "testKey1"));
     assertEquals(1, collection.count());
+  }
+
+  private Map<String, JsonNode> convertToMap(java.util.Collection<Document> docs, String key) {
+    return docs.stream()
+        .map(d -> {
+          try {
+            return OBJECT_MAPPER.reader().readTree(d.toJson());
+          } catch (JsonProcessingException e) {
+            e.printStackTrace();
+          }
+          return null;
+        })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toMap(d -> d.get(key).asText(), d -> d));
   }
 
   @Test
@@ -456,6 +503,14 @@ public class MongoDocStoreTest {
       System.out.println(dbObject);
     }
     assertEquals(1, results.size());
+  }
+
+  private Document createDocument(String ...keys) {
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
+    for (int i = 0; i < keys.length - 1; i++) {
+      objectNode.put(keys[i], keys[i + 1]);
+    }
+    return new JSONDocument(objectNode);
   }
 
   private Document createDocument(String key, String value) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -409,7 +409,7 @@ public class MongoDocStoreTest {
         new SingleValueKey("default", "testKey2"), createDocument("id", "2", "testKey2", "xyz-v1")
     );
 
-    Iterator<Document> iterator = collection.returnAndBulkUpsert(documentMapV1);
+    Iterator<Document> iterator = collection.bulkUpsertAndReturnOlderDocuments(documentMapV1);
     // Initially there shouldn't be any documents.
     Assertions.assertFalse(iterator.hasNext());
 
@@ -418,7 +418,7 @@ public class MongoDocStoreTest {
         new SingleValueKey("default", "testKey1"), createDocument("id", "1", "testKey1", "abc-v2"),
         new SingleValueKey("default", "testKey2"), createDocument("id", "2", "testKey2", "xyz-v2")
     );
-    iterator = collection.returnAndBulkUpsert(documentMapV2);
+    iterator = collection.bulkUpsertAndReturnOlderDocuments(documentMapV2);
     assertEquals(2, collection.count());
     List<Document> documents = new ArrayList<>();
     while (iterator.hasNext()) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
@@ -99,7 +99,7 @@ public class PostgresDocStoreTest {
     query.setFilter(Filter.eq(ID, "default:testKey"));
     Iterator<Document> results = collection.search(query);
     List<Document> documents = new ArrayList<>();
-    for (; results.hasNext(); ) {
+    while (results.hasNext()) {
       documents.add(results.next());
     }
     Assertions.assertFalse(documents.isEmpty());
@@ -165,7 +165,12 @@ public class PostgresDocStoreTest {
     bulkMap.put(
         new SingleValueKey("default", "testKey6"), createDocument("email", "bob@example.com"));
 
-    Iterator<Document> iterator = collection.bulkUpsertAndReturn(bulkMap);
+    Iterator<Document> iterator = collection.returnAndBulkUpsert(bulkMap);
+    // Initially there shouldn't be any documents.
+    Assertions.assertFalse(iterator.hasNext());
+
+    // The operation should be idempotent, so go ahead and try again.
+    iterator = collection.returnAndBulkUpsert(bulkMap);
     List<Document> documents = new ArrayList<>();
     while (iterator.hasNext()) {
       documents.add(iterator.next());
@@ -209,7 +214,7 @@ public class PostgresDocStoreTest {
     query.setFilter(Filter.eq(ID, "default:testKey"));
     Iterator<Document> results = collection.search(query);
     List<Document> documents = new ArrayList<>();
-    for (; results.hasNext(); ) {
+    while (results.hasNext()) {
       documents.add(results.next());
     }
     Assertions.assertFalse(documents.isEmpty());
@@ -269,7 +274,7 @@ public class PostgresDocStoreTest {
   }
 
   @Test
-  public void testDrop() throws IOException {
+  public void testDrop() {
     Collection collection = datastore.getCollection(COLLECTION_NAME);
 
     Assertions.assertTrue(datastore.listCollections().contains("postgres." + COLLECTION_NAME));
@@ -289,7 +294,7 @@ public class PostgresDocStoreTest {
       query.setFilter(new Filter(Filter.Op.LIKE, "name", searchValue));
       Iterator<Document> results = collection.search(query);
       List<Document> documents = new ArrayList<>();
-      for (; results.hasNext(); ) {
+      while (results.hasNext()) {
         documents.add(results.next());
       }
       Assertions.assertFalse(documents.isEmpty());
@@ -331,7 +336,7 @@ public class PostgresDocStoreTest {
         .setFilter(new Filter(Filter.Op.EQ, "attributes.span_id.value.string", "6449f1f720c93a67"));
     Iterator<Document> results = collection.search(query);
     List<Document> documents = new ArrayList<>();
-    for (; results.hasNext(); ) {
+    while (results.hasNext()) {
       documents.add(results.next());
     }
     Assertions.assertEquals(documents.size(), 1);
@@ -387,7 +392,7 @@ public class PostgresDocStoreTest {
 
       Iterator<Document> results = collection.search(query);
       List<Document> documents = new ArrayList<>();
-      for (; results.hasNext(); ) {
+      while (results.hasNext()) {
         documents.add(results.next());
       }
 

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
@@ -165,12 +165,12 @@ public class PostgresDocStoreTest {
     bulkMap.put(
         new SingleValueKey("default", "testKey6"), createDocument("email", "bob@example.com"));
 
-    Iterator<Document> iterator = collection.returnAndBulkUpsert(bulkMap);
+    Iterator<Document> iterator = collection.bulkUpsertAndReturnOlderDocuments(bulkMap);
     // Initially there shouldn't be any documents.
     Assertions.assertFalse(iterator.hasNext());
 
     // The operation should be idempotent, so go ahead and try again.
-    iterator = collection.returnAndBulkUpsert(bulkMap);
+    iterator = collection.bulkUpsertAndReturnOlderDocuments(bulkMap);
     List<Document> documents = new ArrayList<>();
     while (iterator.hasNext()) {
       documents.add(iterator.next());

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -81,6 +81,12 @@ public interface Collection {
   boolean bulkUpsert(Map<Key, Document> documents);
 
   /**
+   * Method to bulkUpsert the given documents and return the latest copies of those documents.
+   * This helps the clients to avoid an additional round trip.
+   */
+  Iterator<Document> bulkUpsertAndReturn(Map<Key, Document> documents) throws IOException;
+
+  /**
    * Drops a collections
    */
   void drop();

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -81,10 +81,11 @@ public interface Collection {
   boolean bulkUpsert(Map<Key, Document> documents);
 
   /**
-   * Method to bulkUpsert the given documents and return the latest copies of those documents.
-   * This helps the clients to avoid an additional round trip.
+   * Method to bulkUpsert the given documents and return the previous copies of those documents.
+   * This helps the clients to see how the documents were prior to upserting them and do that
+   * in one less round trip.
    */
-  Iterator<Document> bulkUpsertAndReturn(Map<Key, Document> documents) throws IOException;
+  Iterator<Document> returnAndBulkUpsert(Map<Key, Document> documents) throws IOException;
 
   /**
    * Drops a collections

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -85,7 +85,7 @@ public interface Collection {
    * This helps the clients to see how the documents were prior to upserting them and do that
    * in one less round trip.
    */
-  Iterator<Document> returnAndBulkUpsert(Map<Key, Document> documents) throws IOException;
+  Iterator<Document> bulkUpsertAndReturnOlderDocuments(Map<Key, Document> documents) throws IOException;
 
   /**
    * Drops a collections

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -412,15 +412,17 @@ public class MongoCollection implements Collection {
   }
 
   @Override
-  public Iterator<Document> bulkUpsertAndReturn(Map<Key, Document> documents) throws IOException {
+  public Iterator<Document> returnAndBulkUpsert(Map<Key, Document> documents) throws IOException {
     try {
+      // First get all the documents for the given keys.
+      FindIterable<BasicDBObject> cursor = collection.find(selectionCriteriaForKeys(documents.keySet()));
+      final MongoCursor<BasicDBObject> mongoCursor = cursor.cursor();
+
+      // Now go ahead and do the bulk upsert.
       BulkWriteResult result = bulkUpsertImpl(documents);
       LOGGER.debug(result.toString());
 
-      FindIterable<BasicDBObject> cursor = collection.find(selectionCriteriaForKeys(documents.keySet()));
-      final MongoCursor<BasicDBObject> mongoCursor = cursor.cursor();
       return new Iterator<>() {
-
         @Override
         public boolean hasNext() {
           return mongoCursor.hasNext();

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -412,7 +412,7 @@ public class MongoCollection implements Collection {
   }
 
   @Override
-  public Iterator<Document> returnAndBulkUpsert(Map<Key, Document> documents) throws IOException {
+  public Iterator<Document> bulkUpsertAndReturnOlderDocuments(Map<Key, Document> documents) throws IOException {
     try {
       // First get all the documents for the given keys.
       FindIterable<BasicDBObject> cursor = collection.find(selectionCriteriaForKeys(documents.keySet()));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import net.jodah.failsafe.Failsafe;
@@ -386,25 +387,53 @@ public class MongoCollection implements Collection {
   @Override
   public boolean bulkUpsert(Map<Key, Document> documents) {
     try {
-      List<UpdateOneModel<BasicDBObject>> bulkCollection = new ArrayList<>();
-      for (Entry<Key, Document> entry : documents.entrySet()) {
-        Key key = entry.getKey();
-        // insert or overwrite
-        bulkCollection.add(new UpdateOneModel<>(
-            this.selectionCriteriaForKey(key),
-            prepareUpsert(key, entry.getValue()),
-            new UpdateOptions().upsert(true)));
-      }
-
-      BulkWriteResult result = Failsafe.with(bulkWriteRetryPolicy)
-          .get(() -> collection.bulkWrite(bulkCollection, new BulkWriteOptions().ordered(false)));
+      BulkWriteResult result = bulkUpsertImpl(documents);
       LOGGER.debug(result.toString());
-
       return true;
-
     } catch (IOException | MongoServerException e) {
       LOGGER.error("Error during bulk upsert for documents:{}", documents, e);
       return false;
+    }
+  }
+
+  private BulkWriteResult bulkUpsertImpl(Map<Key, Document> documents) throws JsonProcessingException {
+    List<UpdateOneModel<BasicDBObject>> bulkCollection = new ArrayList<>();
+    for (Entry<Key, Document> entry : documents.entrySet()) {
+      Key key = entry.getKey();
+      // insert or overwrite
+      bulkCollection.add(new UpdateOneModel<>(
+          this.selectionCriteriaForKey(key),
+          prepareUpsert(key, entry.getValue()),
+          new UpdateOptions().upsert(true)));
+    }
+
+    return Failsafe.with(bulkWriteRetryPolicy)
+        .get(() -> collection.bulkWrite(bulkCollection, new BulkWriteOptions().ordered(false)));
+  }
+
+  @Override
+  public Iterator<Document> bulkUpsertAndReturn(Map<Key, Document> documents) throws IOException {
+    try {
+      BulkWriteResult result = bulkUpsertImpl(documents);
+      LOGGER.debug(result.toString());
+
+      FindIterable<BasicDBObject> cursor = collection.find(selectionCriteriaForKeys(documents.keySet()));
+      final MongoCursor<BasicDBObject> mongoCursor = cursor.cursor();
+      return new Iterator<>() {
+
+        @Override
+        public boolean hasNext() {
+          return mongoCursor.hasNext();
+        }
+
+        @Override
+        public Document next() {
+          return MongoCollection.this.dbObjectToDocument(mongoCursor.next());
+        }
+      };
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Error during bulk upsert for documents:{}", documents, e);
+      throw new IOException("Error during bulk upsert.");
     }
   }
 
@@ -415,6 +444,11 @@ public class MongoCollection implements Collection {
 
   private BasicDBObject selectionCriteriaForKey(Key key) {
     return new BasicDBObject(ID_KEY, key.toString());
+  }
+
+  private BasicDBObject selectionCriteriaForKeys(Set<Key> keys) {
+    return new BasicDBObject(Map.of(ID_KEY, new BasicDBObject("$in",
+        keys.stream().map(Key::toString).collect(Collectors.toList()))));
   }
 
   private Document dbObjectToDocument(BasicDBObject dbObject) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -448,7 +448,7 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public Iterator<Document> returnAndBulkUpsert(Map<Key, Document> documents) throws IOException {
+  public Iterator<Document> bulkUpsertAndReturnOlderDocuments(Map<Key, Document> documents) throws IOException {
     try {
       String collect = documents.keySet().stream()
           .map(val -> "'" + val.toString() + "'")


### PR DESCRIPTION
This will help the clients to build more interesting use cases and also cutdown a roundtrip to the server.

A use case where this has even become essential is more like a change data capture kind of use case: A client wants to upsert a bunch of docs but it needs to know what all changed in those docs compared to the previous version of the docs so that it can optimize some processing. CDC (Change data capture) at the doc store level might be helpful but that's much more heavy weight and doesn't have enough use cases currently to bring that in. 

Also, it's a known that the new API is sync API and could take a bit longer than other APIs so it should be used wisely based on the use cases.