### PR TITLE
Fix equals, hashcode and toString methods

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Filter.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Filter.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.documentstore;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class Filter {
 
@@ -127,10 +128,17 @@ public class Filter {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Filter that = (Filter) o;
-    return op.equals(that.op)
-        && fieldName.equals(that.fieldName)
-        && value.equals(that.value)
-        && Arrays.equals(childFilters, that.childFilters);
+    Filter filter = (Filter) o;
+    return op == filter.op &&
+        Objects.equals(fieldName, filter.fieldName) &&
+        Objects.equals(value, filter.value) &&
+        Arrays.equals(childFilters, filter.childFilters);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(op, fieldName, value);
+    result = 31 * result + Arrays.hashCode(childFilters);
+    return result;
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/OrderBy.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/OrderBy.java
@@ -1,5 +1,7 @@
 package org.hypertrace.core.documentstore;
 
+import java.util.Objects;
+
 public class OrderBy {
 
   private String field;
@@ -9,7 +11,6 @@ public class OrderBy {
     this.field = field;
     this.isAsc = isAsc;
   }
-
 
   public String getField() {
     return field;
@@ -25,5 +26,31 @@ public class OrderBy {
 
   public void setIsAsc(boolean isAsc) {
     this.isAsc = isAsc;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderBy{" +
+        "field='" + field + '\'' +
+        ", isAsc=" + isAsc +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OrderBy orderBy = (OrderBy) o;
+    return isAsc == orderBy.isAsc &&
+        Objects.equals(field, orderBy.field);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(field, isAsc);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Query.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.documentstore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class Query {
 
@@ -49,11 +50,12 @@ public class Query {
 
   @Override
   public String toString() {
-    if (filter == null) {
-      return new Filter().toString();
-    } else {
-      return filter.toString();
-    }
+    return "Query{" +
+        "filter=" + filter +
+        ", orderBys=" + orderBys +
+        ", offset=" + offset +
+        ", limit=" + limit +
+        '}';
   }
 
   @Override
@@ -64,7 +66,15 @@ public class Query {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Query that = (Query) o;
-    return filter.equals(that.filter) && orderBys.equals(that.orderBys);
+    Query query = (Query) o;
+    return Objects.equals(filter, query.filter) &&
+        Objects.equals(orderBys, query.orderBys) &&
+        Objects.equals(offset, query.offset) &&
+        Objects.equals(limit, query.limit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filter, orderBys, offset, limit);
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/FilterTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore;
 
+import org.hypertrace.core.documentstore.Filter.Op;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -60,5 +61,17 @@ public class FilterTest {
 
     Assertions.assertNotNull(filter2.getChildFilters());
     Assertions.assertEquals(0, filter2.getChildFilters().length);
+  }
+
+  @Test
+  public void testEquals() {
+    Filter filter1 = Filter.eq("entity_type", "SERVICE");
+    Filter filter2 = Filter.eq("entity_id", "pod123");
+    Filter filter3 = filter1.and(filter2);
+    Filter filter4 = new Filter(Op.AND, null, null, filter1, filter2);
+    Assertions.assertTrue(filter3.equals(filter4));
+
+    filter4.setChildFilters(new Filter[]{filter1, filter1});
+    Assertions.assertFalse(filter3.equals(filter4));
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/QueryTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/QueryTest.java
@@ -34,4 +34,20 @@ public class QueryTest {
     Assertions.assertEquals("field1", query.getOrderBys().get(0).getField());
     Assertions.assertTrue(query.getOrderBys().get(0).isAsc());
   }
+
+  @Test
+  public void testEquals() {
+    Query query1 = new Query();
+    query1.setFilter(Filter.eq("entity_type", "SERVICE"));
+    query1.addOrderBy(new OrderBy("field1", true));
+
+    Query query2 = new Query();
+    query2.setFilter(Filter.eq("entity_type", "SERVICE"));
+    OrderBy orderBy = new OrderBy("field1", false);
+    query2.addOrderBy(orderBy);
+    Assertions.assertFalse(query1.equals(query2));
+
+    orderBy.setIsAsc(true);
+    Assertions.assertTrue(query1.equals(query2));
+  }
 }


### PR DESCRIPTION
## Description
Fix equals(), hashcode() and toString() methods. 
equals() method in `Filter` and `Query` was throwing NPE previously for some cases(newly added tests demonstrate that). 

### Testing
Updated unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules