### PR TITLE
postgres: Add support for EXISTS and NOT_EXISTS operator

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -598,6 +598,84 @@ public class MongoDocStoreTest {
   }
 
   @Test
+  public void testExistsFilter() throws IOException {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    collection.upsert(new SingleValueKey("default", "testKey1"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey1"),
+                    ImmutablePair.of("name", "abc1"),
+                    ImmutablePair.of("size", -10.2),
+                    ImmutablePair.of("isCostly", false)));
+    collection.upsert(new SingleValueKey("default", "testKey2"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey2"),
+                    ImmutablePair.of("name", "abc2"),
+                    ImmutablePair.of("size", 10.4),
+                    ImmutablePair.of("isCostly", false)));
+    collection.upsert(new SingleValueKey("default", "testKey3"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey3"),
+                    ImmutablePair.of("name", "abc3"),
+                    ImmutablePair.of("size", 30),
+                    ImmutablePair.of("isCostly", false),
+                    ImmutablePair.of("city", "bangalore")));
+    collection.upsert(new SingleValueKey("default", "testKey4"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey4"),
+                    ImmutablePair.of("name", "abc4"),
+                    ImmutablePair.of("size", 30),
+                    ImmutablePair.of("isCostly", false),
+                    ImmutablePair.of("city", null)));
+    Query query = new Query();
+    query.setFilter(new Filter(Op.EXISTS, "city", true));
+    Iterator<Document> results = collection.search(query);
+    List<Document> documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(documents.size(), 2);
+  }
+
+  @Test
+  public void testNotExistsFilter() throws IOException {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    collection.upsert(new SingleValueKey("default", "testKey1"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey1"),
+                    ImmutablePair.of("name", "abc1"),
+                    ImmutablePair.of("size", -10.2),
+                    ImmutablePair.of("isCostly", false)));
+    collection.upsert(new SingleValueKey("default", "testKey2"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey2"),
+                    ImmutablePair.of("name", "abc2"),
+                    ImmutablePair.of("size", 10.4),
+                    ImmutablePair.of("isCostly", false)));
+    collection.upsert(new SingleValueKey("default", "testKey3"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey3"),
+                    ImmutablePair.of("name", "abc3"),
+                    ImmutablePair.of("size", 30),
+                    ImmutablePair.of("isCostly", false),
+                    ImmutablePair.of("city", "bangalore")));
+    collection.upsert(new SingleValueKey("default", "testKey4"),
+            Utils.createDocument(
+                    ImmutablePair.of("id", "testKey4"),
+                    ImmutablePair.of("name", "abc4"),
+                    ImmutablePair.of("size", 30),
+                    ImmutablePair.of("isCostly", false),
+                    ImmutablePair.of("city", null)));
+    Query query = new Query();
+    query.setFilter(new Filter(Op.EXISTS, "city", false));
+    Iterator<Document> results = collection.search(query);
+    List<Document> documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(documents.size(), 2);
+  }
+
+  @Test
   public void testReturnAndBulkUpsert() throws IOException {
     datastore.createCollection(COLLECTION_NAME, null);
     Collection collection = datastore.getCollection(COLLECTION_NAME);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -91,4 +91,6 @@ public interface Collection {
    * Drops a collections
    */
   void drop();
+
+  String UNSUPPORTED_QUERY_OPERATION = "Query operation is not supported";
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -369,9 +369,8 @@ public class MongoCollection implements Collection {
           break;
         case AND:
         case OR:
-          throw new UnsupportedOperationException("AND/OR operator is not supported");
         default:
-          break;
+          throw new UnsupportedOperationException(UNSUPPORTED_QUERY_OPERATION);
       }
       return map;
     }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -119,27 +119,23 @@ public class PostgresCollectionTest {
       Assertions.assertEquals("document->>'_id' = ?", query);
     }
 
+    {
+      Filter filter = new Filter(Filter.Op.EXISTS, "key1.key2", null);
+      String query = collection.parseNonCompositeFilter(filter, initParams());
+      System.err.println(query);
+      Assertions.assertEquals("document->'key1'->'key2' IS NOT NULL ", query);
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
+      String query = collection.parseNonCompositeFilter(filter, initParams());
+      Assertions.assertEquals("document->'key1' IS NULL ", query);
+    }
   }
 
   @Test
   public void testNonCompositeFilterUnsupportedException() {
-    String expectedMessage = "Query operation:%s not supported";
-    {
-      Filter filter = new Filter(Filter.Op.EXISTS, "key1", null);
-      String expected = String.format(expectedMessage, Filter.Op.EXISTS);
-      Exception exception = assertThrows(UnsupportedOperationException.class,
-          () -> collection.parseNonCompositeFilter(filter, initParams()));
-      String actualMessage = exception.getMessage();
-      Assertions.assertTrue(actualMessage.contains(expected));
-    }
-    {
-      Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
-      String expected = String.format(expectedMessage, Filter.Op.NOT_EXISTS);
-      Exception exception = assertThrows(UnsupportedOperationException.class,
-          () -> collection.parseNonCompositeFilter(filter, initParams()));
-      String actualMessage = exception.getMessage();
-      Assertions.assertTrue(actualMessage.contains(expected));
-    }
+    String expectedMessage = collection.UNSUPPORTED_QUERY_OPERATION;
     {
       Filter filter = new Filter(Filter.Op.NEQ, "key1", null);
       String expected = String.format(expectedMessage, Filter.Op.NEQ);
@@ -148,6 +144,7 @@ public class PostgresCollectionTest {
       String actualMessage = exception.getMessage();
       Assertions.assertTrue(actualMessage.contains(expected));
     }
+
     {
       Filter filter = new Filter(Filter.Op.CONTAINS, "key1", null);
       String expected = String.format(expectedMessage, Filter.Op.CONTAINS);


### PR DESCRIPTION
# Description

Add Implementation of EXISTS and NOT_EXISTS operator in postgres.

Addresses the issue https://github.com/hypertrace/document-store/issues/19

## Testing

- Updated unit tests

- Added integration tests for these filters for both mongo and postgres
