### PR TITLE
feat:adds supports for not_in filter in postgres and mongodb

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresDocStoreTest.java
@@ -368,6 +368,168 @@ public class PostgresDocStoreTest {
   }
 
   @Test
+  public void testNotInQueryWithNumberField() throws IOException {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    collection.upsert(new SingleValueKey("default", "testKey1"),
+        Utils.createDocument(
+            ImmutablePair.of("id", "testKey1"),
+            ImmutablePair.of("name", "abc1"),
+            ImmutablePair.of("size", -10.2),
+            ImmutablePair.of("isCostly", false),
+            ImmutablePair.of("tags", List.of("black", "white")),
+            ImmutablePair.of("color", "red")));
+    collection.upsert(new SingleValueKey("default", "testKey2"),
+        Utils.createDocument(
+            ImmutablePair.of("id", "testKey2"),
+            ImmutablePair.of("name", "abc2"),
+            ImmutablePair.of("size", 10.4),
+            ImmutablePair.of("isCostly", false),
+            ImmutablePair.of("tags", List.of("gray")),
+            ImmutablePair.of("color", "gray")));
+    collection.upsert(new SingleValueKey("default", "testKey3"),
+        Utils.createDocument(
+            ImmutablePair.of("id", "testKey3"),
+            ImmutablePair.of("name", "abc3"),
+            ImmutablePair.of("size", 30),
+            ImmutablePair.of("isCostly", false),
+            ImmutablePair.of("tags", List.of("brown")),
+            ImmutablePair.of("color", "blue")));
+    collection.upsert(new SingleValueKey("default", "testKey4"),
+        Utils.createDocument(
+            ImmutablePair.of("id", "testKey4"),
+            ImmutablePair.of("name", "abc4"),
+            ImmutablePair.of("size", 10.4),
+            ImmutablePair.of("isCostly", false),
+            ImmutablePair.of("tags", List.of("gray")),
+            ImmutablePair.of("color", "pink")));
+
+    collection.upsert(new SingleValueKey("default", "testKey5"),
+        Utils.createDocument(
+            ImmutablePair.of("id", "testKey5"),
+            ImmutablePair.of("name", "abc5")));
+
+    collection.updateSubDoc(new SingleValueKey("default", "testKey1"),
+        "subdoc", Utils.createDocument("nestedkey1", "pqr1"));
+    collection.updateSubDoc(new SingleValueKey("default", "testKey2"),
+        "subdoc", Utils.createDocument("nestedkey1", "pqr2"));
+    collection.updateSubDoc(new SingleValueKey("default", "testKey3"),
+        "subdoc", Utils.createDocument("nestedkey1", "pqr3"));
+
+
+    // check with string filed
+    List<String> names = new ArrayList<>();
+    names.add("abc3");
+    names.add("abc2");
+
+    Query query = new Query();
+    query.setFilter(new Filter(Filter.Op.NOT_IN, "name", names));
+    Iterator<Document> results = collection.search(query);
+    List<Document> documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(3, documents.size());
+    documents.forEach(document -> {
+      String jsonStr = document.toJson();
+      assertTrue(jsonStr.contains("\"name\":\"abc1\"")
+          || jsonStr.contains("\"name\":\"abc4\"")
+          || jsonStr.contains("\"name\":\"abc5\""));
+    });
+
+    // check with multiple operator and + not_in with string field
+    List<String> colors = new ArrayList<>();
+    colors.add("red");
+    colors.add("pink");
+
+    query = new Query();
+    Filter[] filters = new Filter[2];
+    filters[0] = new Filter(Op.EQ, "size", 10.4);
+    filters[1] = new Filter(Filter.Op.NOT_IN, "color", colors);
+    Filter f = new Filter();
+    f.setOp(Op.OR);
+    f.setChildFilters(filters);
+    query.setFilter(f);
+    results = collection.search(query);
+    documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(4, documents.size());
+    documents.forEach(document -> {
+      String jsonStr = document.toJson();
+      assertTrue(jsonStr.contains("\"name\":\"abc2\"")
+          || jsonStr.contains("\"name\":\"abc3\"")
+          || jsonStr.contains("\"name\":\"abc4\"")
+          || jsonStr.contains("\"name\":\"abc5\""));
+    });
+
+    // check with numeric field
+    List<Number> sizes = new ArrayList<>();
+    sizes.add(-10.2);
+    sizes.add(10.4);
+
+    query = new Query();
+    query.setFilter(new Filter(Filter.Op.NOT_IN, "size", sizes));
+    results = collection.search(query);
+    documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(2, documents.size());
+    documents.forEach(document -> {
+      String jsonStr = document.toJson();
+      assertTrue(jsonStr.contains("\"name\":\"abc3\"")
+          || jsonStr.contains("\"name\":\"abc5\""));
+    });
+
+    // check with multiple operator and + not_in with numeric field
+    sizes = new ArrayList<>();
+    sizes.add(-10.2);
+    sizes.add(10.4);
+
+    query = new Query();
+    filters = new Filter[2];
+    filters[0] = new Filter(Op.EQ, "color", "pink");
+    filters[1] = new Filter(Filter.Op.NOT_IN, "size", sizes);
+    f = new Filter();
+    f.setOp(Op.OR);
+    f.setChildFilters(filters);
+    query.setFilter(f);
+    results = collection.search(query);
+    documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    Assertions.assertEquals(3, documents.size());
+    documents.forEach(document -> {
+      String jsonStr = document.toJson();
+      assertTrue(jsonStr.contains("\"name\":\"abc3\"")
+          || jsonStr.contains("\"name\":\"abc4\"")
+          || jsonStr.contains("\"name\":\"abc5\""));
+    });
+
+    // check for subDoc key
+    List<String> subDocs = new ArrayList<>();
+    subDocs.add("pqr1");
+    subDocs.add("pqr2");
+
+    query = new Query();
+    query.setFilter(new Filter(Op.NOT_IN, "subdoc.nestedkey1", subDocs));
+    results = collection.search(query);
+    documents = new ArrayList<>();
+    while (results.hasNext()) {
+      documents.add(results.next());
+    }
+    assertEquals(3, documents.size());
+    documents.forEach(document -> {
+      String jsonStr = document.toJson();
+      assertTrue(jsonStr.contains("\"name\":\"abc3\"")
+          || jsonStr.contains("\"name\":\"abc4\"")
+          || jsonStr.contains("\"name\":\"abc5\""));
+    });
+  }
+
+  @Test
   public void testSearch() throws IOException {
     Collection collection = datastore.getCollection(COLLECTION_NAME);
     String docStr1 = "{\"amount\":1234.5,\"testKeyExist\":null,\"attributes\":{\"trace_id\":{\"value\":{\"string\":\"00000000000000005e194fdf9fbf5101\"}},\"span_id\":{\"value\":{\"string\":\"6449f1f720c93a67\"}},\"service_type\":{\"value\":{\"string\":\"JAEGER_SERVICE\"}},\"FQN\":{\"value\":{\"string\":\"driver\"}}},\"createdTime\":1605692185945,\"entityId\":\"e3ffc6f0-fc92-3a9c-9fa0-26269184d1aa\",\"entityName\":\"driver\",\"entityType\":\"SERVICE\",\"identifyingAttributes\":{\"FQN\":{\"value\":{\"string\":\"driver\"}}},\"tenantId\":\"__default\"}";

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
@@ -1,7 +1,9 @@
 package org.hypertrace.core.documentstore.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.JSONDocument;
@@ -18,8 +20,10 @@ public class Utils {
         objectNode.put(paris[i].getLeft(), (Double)(paris[i].getRight()));
       } else if (paris[i].getRight() instanceof Boolean) {
         objectNode.put(paris[i].getLeft(), (Boolean) (paris[i].getRight()));
-      } else {
+      } else if (paris[i].getRight() instanceof String) {
         objectNode.put(paris[i].getLeft(), (String)(paris[i].getRight()));
+      } else {
+        objectNode.putPOJO(paris[i].getLeft(), paris[i].getRight());
       }
     }
     return new JSONDocument(objectNode);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Filter.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Filter.java
@@ -23,7 +23,8 @@ public class Filter {
     CONTAINS,
     EXISTS,
     NOT_EXISTS,
-    LIKE
+    LIKE,
+    NOT_IN
   }
 
   public Filter() {}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -336,6 +336,9 @@ public class MongoCollection implements Collection {
           map.put(
               filter.getFieldName(), new BasicDBObject("$regex", value).append("$options", "i"));
           break;
+        case NOT_IN:
+          map.put(filter.getFieldName(), new BasicDBObject("$nin", value));
+          break;
         case IN:
           map.put(filter.getFieldName(), new BasicDBObject("$in", value));
           break;

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.bson.conversions.Bson;
 import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.Filter.Op;
 import org.hypertrace.core.documentstore.Query;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,6 +90,12 @@ public class MongoCollectionTest {
       Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
       Map<String, Object> query = mongoCollection.parseQuery(filter);
       assertEquals(new BasicDBObject("$in", List.of("abc", "xyz")), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
+      Map<String, Object> query = mongoCollection.parseQuery(filter);
+      assertEquals(new BasicDBObject("$nin", List.of("abc", "xyz")), query.get("key1"));
     }
 
     {

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import java.sql.Connection;
 import java.util.List;
 import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.Filter.Op;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,6 +124,12 @@ public class PostgresCollectionTest {
       Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
       String query = collection.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' IN (?, ?)", query);
+    }
+
+    {
+      Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
+      String query = collection.parseNonCompositeFilter(filter, initParams());
+      Assertions.assertEquals("document->'key1' IS NULL OR document->>'key1' NOT IN (?, ?)", query);
     }
 
     {


### PR DESCRIPTION
## Description
Provides an implementation of an issue - https://github.com/hypertrace/document-store/issues/32 - of adding `not_in` filter.
It implements for both mongo + Postgres implementation of document store interface. However, there is some limitation on
postgres side. On Postgres side, it only supports non-array field and highlighted here - https://github.com/hypertrace/document-store/issues/32#issuecomment-781411676

### Testing
- Adds integration tests for various scenarios

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
None. will be covered in the release note.
