### PR TITLE
Issue: https://github.com/hypertrace/document-store/issues/48

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Triple;
+import org.hypertrace.core.documentstore.BulkUpdateResult;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Datastore;
 import org.hypertrace.core.documentstore.DatastoreProvider;
@@ -173,8 +174,8 @@ public class MongoDocStoreTest {
     toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(objectNode),
         new Filter(Op.LT, "timestamp", 100)));
 
-    boolean result = collection.bulkUpdate(toUpdate);
-    Assertions.assertTrue(result);
+    BulkUpdateResult result = collection.bulkUpdate(toUpdate);
+    Assertions.assertEquals(0, result.getUpdatedCount());
 
     Query query = new Query();
     query
@@ -205,9 +206,8 @@ public class MongoDocStoreTest {
     toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(updatedObject),
         new Filter(Op.LT, "timestamp", 100)));
 
-    boolean result = collection.bulkUpdate(toUpdate);
-    Assertions.assertTrue(result);
-    Assertions.assertEquals(1, collection.count());
+    BulkUpdateResult result = collection.bulkUpdate(toUpdate);
+    Assertions.assertEquals(1, result.getUpdatedCount());
 
     Query query = new Query();
     query

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.documentstore.mongo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,6 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Datastore;
 import org.hypertrace.core.documentstore.DatastoreProvider;
@@ -155,6 +157,65 @@ public class MongoDocStoreTest {
 
     assertEquals("bar1", node.get("foo1").asText());
     assertEquals("bar2", node.get("foo2").asText());
+  }
+
+  @Test
+  public void whenBulkUpdatingNonExistentRecords_thenExpectNothingToBeUpdatedOrCreated()
+      throws Exception {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
+    objectNode.put("foo1", "bar1");
+    objectNode.put("timestamp", 100);
+
+    List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
+    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(objectNode),
+        new Filter(Op.LT, "timestamp", 100)));
+    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(objectNode),
+        new Filter(Op.LT, "timestamp", 100)));
+
+    boolean result = collection.bulkUpdate(toUpdate);
+    Assertions.assertTrue(result);
+
+    Query query = new Query();
+    query
+        .setFilter(new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
+    Iterator<Document> it = collection.search(query);
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void whenBulkUpdatingExistingRecords_thenExpectOnlyRecordsWhoseConditionsMatchToBeUpdated()
+      throws Exception {
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    ObjectNode persistedObject = OBJECT_MAPPER.createObjectNode();
+    persistedObject.put("foo1", "bar1");
+    persistedObject.put("timestamp", 90);
+
+    collection.create(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(persistedObject));
+
+    ObjectNode updatedObject = OBJECT_MAPPER.createObjectNode();
+    updatedObject.put("foo1", "bar1");
+    updatedObject.put("timestamp", 110);
+
+
+    List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
+    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(updatedObject),
+        new Filter(Op.LT, "timestamp", 100)));
+
+    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(updatedObject),
+        new Filter(Op.LT, "timestamp", 100)));
+
+    boolean result = collection.bulkUpdate(toUpdate);
+    Assertions.assertTrue(result);
+    Assertions.assertEquals(1, collection.count());
+
+    Query query = new Query();
+    query
+        .setFilter(new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
+    Iterator<Document> it = collection.search(query);
+    JsonNode root = OBJECT_MAPPER.readTree(it.next().toJson());
+    Long timestamp = root.findValue("timestamp").asLong();
+    Assertions.assertEquals(110, timestamp);
   }
 
   @Test

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -169,17 +169,23 @@ public class MongoDocStoreTest {
     objectNode.put("timestamp", 100);
 
     List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
-    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(objectNode),
-        new Filter(Op.LT, "timestamp", 100)));
-    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(objectNode),
-        new Filter(Op.LT, "timestamp", 100)));
+    toUpdate.add(
+        Triple.of(
+            new SingleValueKey("tenant-1", "testKey1"),
+            new JSONDocument(objectNode),
+            new Filter(Op.LT, "timestamp", 100)));
+    toUpdate.add(
+        Triple.of(
+            new SingleValueKey("tenant-1", "testKey2"),
+            new JSONDocument(objectNode),
+            new Filter(Op.LT, "timestamp", 100)));
 
     BulkUpdateResult result = collection.bulkUpdate(toUpdate);
     Assertions.assertEquals(0, result.getUpdatedCount());
 
     Query query = new Query();
-    query
-        .setFilter(new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
+    query.setFilter(
+        new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
     Iterator<Document> it = collection.search(query);
     assertFalse(it.hasNext());
   }
@@ -192,26 +198,32 @@ public class MongoDocStoreTest {
     persistedObject.put("foo1", "bar1");
     persistedObject.put("timestamp", 90);
 
-    collection.create(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(persistedObject));
+    collection.create(
+        new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(persistedObject));
 
     ObjectNode updatedObject = OBJECT_MAPPER.createObjectNode();
     updatedObject.put("foo1", "bar1");
     updatedObject.put("timestamp", 110);
 
-
     List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
-    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey1"), new JSONDocument(updatedObject),
-        new Filter(Op.LT, "timestamp", 100)));
+    toUpdate.add(
+        Triple.of(
+            new SingleValueKey("tenant-1", "testKey1"),
+            new JSONDocument(updatedObject),
+            new Filter(Op.LT, "timestamp", 100)));
 
-    toUpdate.add(Triple.of(new SingleValueKey("tenant-1", "testKey2"), new JSONDocument(updatedObject),
-        new Filter(Op.LT, "timestamp", 100)));
+    toUpdate.add(
+        Triple.of(
+            new SingleValueKey("tenant-1", "testKey2"),
+            new JSONDocument(updatedObject),
+            new Filter(Op.LT, "timestamp", 100)));
 
     BulkUpdateResult result = collection.bulkUpdate(toUpdate);
     Assertions.assertEquals(1, result.getUpdatedCount());
 
     Query query = new Query();
-    query
-        .setFilter(new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
+    query.setFilter(
+        new Filter(Op.EQ, "_id", new SingleValueKey("tenant-1", "testKey1").toString()));
     Iterator<Document> it = collection.search(query);
     JsonNode root = OBJECT_MAPPER.readTree(it.next().toJson());
     Long timestamp = root.findValue("timestamp").asLong();

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoDocStoreTest.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Triple;
+import org.hypertrace.core.documentstore.BulkUpdateRequest;
 import org.hypertrace.core.documentstore.BulkUpdateResult;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.Datastore;
@@ -168,14 +168,14 @@ public class MongoDocStoreTest {
     objectNode.put("foo1", "bar1");
     objectNode.put("timestamp", 100);
 
-    List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
+    List<BulkUpdateRequest> toUpdate = new ArrayList<>();
     toUpdate.add(
-        Triple.of(
+        new BulkUpdateRequest(
             new SingleValueKey("tenant-1", "testKey1"),
             new JSONDocument(objectNode),
             new Filter(Op.LT, "timestamp", 100)));
     toUpdate.add(
-        Triple.of(
+        new BulkUpdateRequest(
             new SingleValueKey("tenant-1", "testKey2"),
             new JSONDocument(objectNode),
             new Filter(Op.LT, "timestamp", 100)));
@@ -205,15 +205,15 @@ public class MongoDocStoreTest {
     updatedObject.put("foo1", "bar1");
     updatedObject.put("timestamp", 110);
 
-    List<Triple<Key, Document, Filter>> toUpdate = new ArrayList<>();
+    List<BulkUpdateRequest> toUpdate = new ArrayList<>();
     toUpdate.add(
-        Triple.of(
+        new BulkUpdateRequest(
             new SingleValueKey("tenant-1", "testKey1"),
             new JSONDocument(updatedObject),
             new Filter(Op.LT, "timestamp", 100)));
 
     toUpdate.add(
-        Triple.of(
+        new BulkUpdateRequest(
             new SingleValueKey("tenant-1", "testKey2"),
             new JSONDocument(updatedObject),
             new Filter(Op.LT, "timestamp", 100)));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateRequest.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateRequest.java
@@ -1,0 +1,38 @@
+package org.hypertrace.core.documentstore;
+
+public class BulkUpdateRequest {
+
+  private final Key key;
+  private final Document document;
+  private final Filter filter;
+
+  public BulkUpdateRequest(Key key, Document document, Filter filter) {
+    this.key = key;
+    this.document = document;
+    this.filter = filter;
+  }
+
+  public Key getKey() {
+    return key;
+  }
+
+  public Document getDocument() {
+    return document;
+  }
+
+  public Filter getFilter() {
+    return filter;
+  }
+
+  @Override
+  public String toString() {
+    return "BulkUpdateRequest{"
+        + "key="
+        + key
+        + ", document="
+        + document
+        + ", filter="
+        + filter
+        + '}';
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateResult.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateResult.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.documentstore;
 
-public class BulkUpdateResult extends UpdateResult{
+public class BulkUpdateResult extends UpdateResult {
 
   public BulkUpdateResult(long updatedCount) {
     super(updatedCount);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateResult.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/BulkUpdateResult.java
@@ -1,0 +1,8 @@
+package org.hypertrace.core.documentstore;
+
+public class BulkUpdateResult extends UpdateResult{
+
+  public BulkUpdateResult(long updatedCount) {
+    super(updatedCount);
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -2,7 +2,9 @@ package org.hypertrace.core.documentstore;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Triple;
 
 /** Interface spec for common operations on a collection of documents */
 public interface Collection {
@@ -101,6 +103,14 @@ public interface Collection {
    * @return an instance of {@link CreateResult}
    */
   CreateResult create(Key key, Document document) throws IOException;
+
+  /**
+   * Updates existing documents if the corresponding Filter condition evaluates to true
+   * @param documents to be updated in bulk
+   * @return true if operation succeeded
+   */
+  boolean bulkUpdate(List<Triple<Key, Document, Filter>> documents);
+
 
   /**
    * Update an existing document if condition is evaluated to true. Condition will help in providing

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.tuple.Triple;
 
 /** Interface spec for common operations on a collection of documents */
 public interface Collection {
@@ -110,7 +109,7 @@ public interface Collection {
    * @param documents to be updated in bulk
    * @return true if operation succeeded
    */
-  BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception;
+  BulkUpdateResult bulkUpdate(List<BulkUpdateRequest> bulkUpdateRequests) throws Exception;
 
   /**
    * Update an existing document if condition is evaluated to true. Condition will help in providing

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -107,7 +107,7 @@ public interface Collection {
    * Updates existing documents if the corresponding Filter condition evaluates to true
    *
    * @param documents to be updated in bulk
-   * @return true if operation succeeded
+   * @return an instance of {@link BulkUpdateResult}
    */
   BulkUpdateResult bulkUpdate(List<BulkUpdateRequest> bulkUpdateRequests) throws Exception;
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -106,11 +106,11 @@ public interface Collection {
 
   /**
    * Updates existing documents if the corresponding Filter condition evaluates to true
+   *
    * @param documents to be updated in bulk
    * @return true if operation succeeded
    */
   BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception;
-
 
   /**
    * Update an existing document if condition is evaluated to true. Condition will help in providing

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -109,7 +109,7 @@ public interface Collection {
    * @param documents to be updated in bulk
    * @return true if operation succeeded
    */
-  boolean bulkUpdate(List<Triple<Key, Document, Filter>> documents);
+  BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception;
 
 
   /**

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.hypertrace.core.documentstore.BulkUpdateResult;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.CreateResult;
 import org.hypertrace.core.documentstore.Document;
@@ -138,14 +139,16 @@ public class MongoCollection implements Collection {
    * Bulk updates existing documents if condition for the corresponding document evaluates to true.
    */
   @Override
-  public boolean bulkUpdate(List<Triple<Key, Document, Filter>> documents) {
+  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception {
     try {
       BulkWriteResult result = bulkUpdateImpl(documents);
-      LOGGER.debug(result.toString());
-      return true;
+      if(LOGGER.isDebugEnabled()) {
+        LOGGER.debug(result.toString());
+      }
+      return new BulkUpdateResult(result.getModifiedCount());
     } catch (IOException | MongoServerException e) {
       LOGGER.error("Error during bulk update for documents:{}", documents, e);
-      return false;
+      throw new Exception(e);
     }
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonMode;
@@ -139,10 +138,11 @@ public class MongoCollection implements Collection {
    * Bulk updates existing documents if condition for the corresponding document evaluates to true.
    */
   @Override
-  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception {
+  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents)
+      throws Exception {
     try {
       BulkWriteResult result = bulkUpdateImpl(documents);
-      if(LOGGER.isDebugEnabled()) {
+      if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(result.toString());
       }
       return new BulkUpdateResult(result.getModifiedCount());

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -140,7 +140,8 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception {
+  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents)
+      throws Exception {
     throw new UnsupportedOperationException();
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.CreateResult;
 import org.hypertrace.core.documentstore.Document;
@@ -135,6 +136,11 @@ public class PostgresCollection implements Collection {
       LOGGER.error("SQLException creating document. key: {} content:{}", key, document, e);
       throw new IOException(e);
     }
+  }
+
+  @Override
+  public boolean bulkUpdate(List<Triple<Key, Document, Filter>> documents) {
+    throw new UnsupportedOperationException();
   }
 
   /**

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
+import org.hypertrace.core.documentstore.BulkUpdateResult;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.CreateResult;
 import org.hypertrace.core.documentstore.Document;
@@ -139,7 +140,7 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public boolean bulkUpdate(List<Triple<Key, Document, Filter>> documents) {
+  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents) throws Exception {
     throw new UnsupportedOperationException();
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Triple;
+import org.hypertrace.core.documentstore.BulkUpdateRequest;
 import org.hypertrace.core.documentstore.BulkUpdateResult;
 import org.hypertrace.core.documentstore.Collection;
 import org.hypertrace.core.documentstore.CreateResult;
@@ -140,8 +140,7 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public BulkUpdateResult bulkUpdate(List<Triple<Key, Document, Filter>> documents)
-      throws Exception {
+  public BulkUpdateResult bulkUpdate(List<BulkUpdateRequest> bulkUpdateRequests) throws Exception {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
Add bulk update API implementation for Mongo. This PR does not provide an implementation for postgresql and can be added in a follow up PR


