### PR TITLE
Fixes #50: Handle sorting of documents on multiple attributes

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -844,6 +844,9 @@ public class DocStoreTest {
       query.setLimit(2);
       query.setOffset(1);
       query.addOrderBy(new OrderBy("_id", true));
+      query.addOrderBy(new OrderBy("foo1", true));
+      query.addOrderBy(new OrderBy("foo2", true));
+      query.addOrderBy(new OrderBy("foo3", true));
 
       Iterator<Document> results = collection.search(query);
       List<Document> documents = new ArrayList<>();

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -361,9 +362,7 @@ public class MongoCollection implements Collection {
     }
 
     if (!query.getOrderBys().isEmpty()) {
-      Map<String, Object> orderbyMap = new HashMap<>();
-      parseOrderByQuery(query.getOrderBys(), orderbyMap);
-      BasicDBObject orderBy = new BasicDBObject(orderbyMap);
+      BasicDBObject orderBy = new BasicDBObject(parseOrderByQuery(query.getOrderBys()));
       cursor.sort(orderBy);
     }
 
@@ -409,10 +408,13 @@ public class MongoCollection implements Collection {
     return true;
   }
 
-  private void parseOrderByQuery(List<OrderBy> orderBys, Map<String, Object> orderbyMap) {
+  @VisibleForTesting
+  LinkedHashMap<String, Object> parseOrderByQuery(List<OrderBy> orderBys) {
+    LinkedHashMap<String, Object> orderByMap = new LinkedHashMap<>();
     for (OrderBy orderBy : orderBys) {
-      orderbyMap.put(orderBy.getField(), (orderBy.isAsc() ? 1 : -1));
+      orderByMap.put(orderBy.getField(), (orderBy.isAsc() ? 1 : -1));
     }
+    return orderByMap;
   }
 
   @VisibleForTesting

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoCommandException;
@@ -26,10 +25,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -49,7 +46,6 @@ import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.Key;
-import org.hypertrace.core.documentstore.OrderBy;
 import org.hypertrace.core.documentstore.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,7 +157,7 @@ public class MongoCollection implements Collection {
       Map<String, Object> conditionMap =
           bulkUpdateRequest.getFilter() == null
               ? new HashMap<>()
-              : parseQuery(bulkUpdateRequest.getFilter());
+              : MongoQueryParser.parseFilter(bulkUpdateRequest.getFilter());
       conditionMap.put(ID_KEY, key.toString());
       BasicDBObject conditionObject = new BasicDBObject(conditionMap);
 
@@ -186,7 +182,7 @@ public class MongoCollection implements Collection {
       Key key, Document document, Filter condition) throws IOException {
     try {
       Map<String, Object> conditionMap =
-          condition == null ? new HashMap<>() : parseQuery(condition);
+          condition == null ? new HashMap<>() : MongoQueryParser.parseFilter(condition);
       conditionMap.put(ID_KEY, key.toString());
       BasicDBObject conditionObject = new BasicDBObject(conditionMap);
       UpdateOptions options = new UpdateOptions().upsert(false);
@@ -332,7 +328,7 @@ public class MongoCollection implements Collection {
 
     // If there is a filter in the query, parse it fully.
     if (query.getFilter() != null) {
-      map = parseQuery(query.getFilter());
+      map = MongoQueryParser.parseFilter(query.getFilter());
     }
 
     Bson projection = new BasicDBObject();
@@ -362,7 +358,8 @@ public class MongoCollection implements Collection {
     }
 
     if (!query.getOrderBys().isEmpty()) {
-      BasicDBObject orderBy = new BasicDBObject(parseOrderByQuery(query.getOrderBys()));
+      BasicDBObject orderBy =
+          new BasicDBObject(MongoQueryParser.parseOrderBys(query.getOrderBys()));
       cursor.sort(orderBy);
     }
 
@@ -408,94 +405,6 @@ public class MongoCollection implements Collection {
     return true;
   }
 
-  @VisibleForTesting
-  LinkedHashMap<String, Object> parseOrderByQuery(List<OrderBy> orderBys) {
-    LinkedHashMap<String, Object> orderByMap = new LinkedHashMap<>();
-    for (OrderBy orderBy : orderBys) {
-      orderByMap.put(orderBy.getField(), (orderBy.isAsc() ? 1 : -1));
-    }
-    return orderByMap;
-  }
-
-  @VisibleForTesting
-  Map<String, Object> parseQuery(Filter filter) {
-    if (filter.isComposite()) {
-      Filter.Op op = filter.getOp();
-      switch (op) {
-        case OR:
-        case AND:
-          {
-            List<Map<String, Object>> childMapList =
-                Arrays.stream(filter.getChildFilters())
-                    .map(this::parseQuery)
-                    .filter(map -> !map.isEmpty())
-                    .collect(Collectors.toList());
-            if (!childMapList.isEmpty()) {
-              return Map.of("$" + op.name().toLowerCase(), childMapList);
-            } else {
-              return Collections.emptyMap();
-            }
-          }
-        default:
-          throw new UnsupportedOperationException(
-              String.format("Boolean operation:%s not supported", op));
-      }
-    } else {
-      Filter.Op op = filter.getOp();
-      Object value = filter.getValue();
-      Map<String, Object> map = new HashMap<>();
-      switch (op) {
-        case EQ:
-          map.put(filter.getFieldName(), value);
-          break;
-        case LIKE:
-          // Case insensitive regex search
-          map.put(
-              filter.getFieldName(), new BasicDBObject("$regex", value).append("$options", "i"));
-          break;
-        case NOT_IN:
-          map.put(filter.getFieldName(), new BasicDBObject("$nin", value));
-          break;
-        case IN:
-          map.put(filter.getFieldName(), new BasicDBObject("$in", value));
-          break;
-        case CONTAINS:
-          map.put(filter.getFieldName(), new BasicDBObject("$elemMatch", filter.getValue()));
-          break;
-        case GT:
-          map.put(filter.getFieldName(), new BasicDBObject("$gt", value));
-          break;
-        case LT:
-          map.put(filter.getFieldName(), new BasicDBObject("$lt", value));
-          break;
-        case GTE:
-          map.put(filter.getFieldName(), new BasicDBObject("$gte", value));
-          break;
-        case LTE:
-          map.put(filter.getFieldName(), new BasicDBObject("$lte", value));
-          break;
-        case EXISTS:
-          map.put(filter.getFieldName(), new BasicDBObject("$exists", true));
-          break;
-        case NOT_EXISTS:
-          map.put(filter.getFieldName(), new BasicDBObject("$exists", false));
-          break;
-        case NEQ:
-          // $ne operator in Mongo also returns the results, where the key does not exist in the
-          // document. This is as per semantics of EQ vs NEQ. So, if you need documents where
-          // key exists, consumer needs to add additional filter.
-          // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520
-          map.put(filter.getFieldName(), new BasicDBObject("$ne", value));
-          break;
-        case AND:
-        case OR:
-        default:
-          throw new UnsupportedOperationException(UNSUPPORTED_QUERY_OPERATION);
-      }
-      return map;
-    }
-  }
-
   @Override
   public long count() {
     return collection.countDocuments();
@@ -507,7 +416,7 @@ public class MongoCollection implements Collection {
 
     // If there is a filter in the query, parse it fully.
     if (query.getFilter() != null) {
-      map = parseQuery(query.getFilter());
+      map = MongoQueryParser.parseFilter(query.getFilter());
     }
 
     return collection.countDocuments(new BasicDBObject(map));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
@@ -1,0 +1,103 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import static org.hypertrace.core.documentstore.Collection.UNSUPPORTED_QUERY_OPERATION;
+
+import com.mongodb.BasicDBObject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.OrderBy;
+
+public class MongoQueryParser {
+
+  static Map<String, Object> parseFilter(Filter filter) {
+    if (filter.isComposite()) {
+      Filter.Op op = filter.getOp();
+      switch (op) {
+        case OR:
+        case AND:
+          {
+            List<Map<String, Object>> childMapList =
+                Arrays.stream(filter.getChildFilters())
+                    .map(MongoQueryParser::parseFilter)
+                    .filter(map -> !map.isEmpty())
+                    .collect(Collectors.toList());
+            if (!childMapList.isEmpty()) {
+              return Map.of("$" + op.name().toLowerCase(), childMapList);
+            } else {
+              return Collections.emptyMap();
+            }
+          }
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Boolean operation:%s not supported", op));
+      }
+    } else {
+      Filter.Op op = filter.getOp();
+      Object value = filter.getValue();
+      Map<String, Object> map = new HashMap<>();
+      switch (op) {
+        case EQ:
+          map.put(filter.getFieldName(), value);
+          break;
+        case LIKE:
+          // Case insensitive regex search
+          map.put(
+              filter.getFieldName(), new BasicDBObject("$regex", value).append("$options", "i"));
+          break;
+        case NOT_IN:
+          map.put(filter.getFieldName(), new BasicDBObject("$nin", value));
+          break;
+        case IN:
+          map.put(filter.getFieldName(), new BasicDBObject("$in", value));
+          break;
+        case CONTAINS:
+          map.put(filter.getFieldName(), new BasicDBObject("$elemMatch", filter.getValue()));
+          break;
+        case GT:
+          map.put(filter.getFieldName(), new BasicDBObject("$gt", value));
+          break;
+        case LT:
+          map.put(filter.getFieldName(), new BasicDBObject("$lt", value));
+          break;
+        case GTE:
+          map.put(filter.getFieldName(), new BasicDBObject("$gte", value));
+          break;
+        case LTE:
+          map.put(filter.getFieldName(), new BasicDBObject("$lte", value));
+          break;
+        case EXISTS:
+          map.put(filter.getFieldName(), new BasicDBObject("$exists", true));
+          break;
+        case NOT_EXISTS:
+          map.put(filter.getFieldName(), new BasicDBObject("$exists", false));
+          break;
+        case NEQ:
+          // $ne operator in Mongo also returns the results, where the key does not exist in the
+          // document. This is as per semantics of EQ vs NEQ. So, if you need documents where
+          // key exists, consumer needs to add additional filter.
+          // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520
+          map.put(filter.getFieldName(), new BasicDBObject("$ne", value));
+          break;
+        case AND:
+        case OR:
+        default:
+          throw new UnsupportedOperationException(UNSUPPORTED_QUERY_OPERATION);
+      }
+      return map;
+    }
+  }
+
+  static LinkedHashMap<String, Object> parseOrderBys(List<OrderBy> orderBys) {
+    LinkedHashMap<String, Object> orderByMap = new LinkedHashMap<>();
+    for (OrderBy orderBy : orderBys) {
+      orderByMap.put(orderBy.getField(), (orderBy.isAsc() ? 1 : -1));
+    }
+    return orderByMap;
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.OrderBy;
 
-public class MongoQueryParser {
+class MongoQueryParser {
 
   static Map<String, Object> parseFilter(Filter filter) {
     if (filter.isComposite()) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
@@ -1,0 +1,260 @@
+package org.hypertrace.core.documentstore.postgres;
+
+import static org.hypertrace.core.documentstore.Collection.UNSUPPORTED_QUERY_OPERATION;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.CREATED_AT;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOCUMENT;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOC_PATH_SEPARATOR;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.ID;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.UPDATED_AT;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.OrderBy;
+import org.hypertrace.core.documentstore.postgres.Params.Builder;
+
+class PostgresQueryParser {
+
+  private static final String QUESTION_MARK = "?";
+  // postgres jsonb uses `->` instead of `.` for json field access
+  private static final String JSON_FIELD_ACCESSOR = "->";
+  // postgres operator to fetch the value of json object as text.
+  private static final String JSON_DATA_ACCESSOR = "->>";
+  private static final Set<String> OUTER_COLUMNS =
+      new HashSet<>() {
+        {
+          add(CREATED_AT);
+          add(ID);
+          add(UPDATED_AT);
+        }
+      };
+
+  static String parseFilter(Filter filter, Builder paramsBuilder) {
+    if (filter.isComposite()) {
+      return parseCompositeFilter(filter, paramsBuilder);
+    } else {
+      return parseNonCompositeFilter(filter, paramsBuilder);
+    }
+  }
+
+  static String parseNonCompositeFilter(Filter filter, Builder paramsBuilder) {
+    Filter.Op op = filter.getOp();
+    Object value = filter.getValue();
+    String fieldName = filter.getFieldName();
+    String fullFieldName = prepareCast(prepareFieldDataAccessorExpr(fieldName), value);
+    StringBuilder filterString = new StringBuilder(fullFieldName);
+    String sqlOperator;
+    Boolean isMultiValued = false;
+    switch (op) {
+      case EQ:
+        sqlOperator = " = ";
+        break;
+      case GT:
+        sqlOperator = " > ";
+        break;
+      case LT:
+        sqlOperator = " < ";
+        break;
+      case GTE:
+        sqlOperator = " >= ";
+        break;
+      case LTE:
+        sqlOperator = " <= ";
+        break;
+      case LIKE:
+        // Case insensitive regex search, Append % at beginning and end of value to do a regex
+        // search
+        sqlOperator = " ILIKE ";
+        value = "%" + value + "%";
+        break;
+      case NOT_IN:
+        // NOTE: Below two points
+        // 1. both NOT_IN and IN filter currently limited to non-array field
+        //    - https://github.com/hypertrace/document-store/issues/32#issuecomment-781411676
+        // 2. To make semantically opposite filter of IN, we need to check for if key is not present
+        //    Ref in context of NEQ -
+        // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520Other
+        //    so, we need - "document->key IS NULL OR document->key->> NOT IN (v1, v2)"
+        StringBuilder notInFilterString = prepareFieldAccessorExpr(fieldName);
+        if (notInFilterString != null) {
+          filterString = notInFilterString.append(" IS NULL OR ").append(fullFieldName);
+        }
+        sqlOperator = " NOT IN ";
+        isMultiValued = true;
+        value = prepareParameterizedStringForList((List<Object>) value, paramsBuilder);
+        break;
+      case IN:
+        // NOTE: both NOT_IN and IN filter currently limited to non-array field
+        //  - https://github.com/hypertrace/document-store/issues/32#issuecomment-781411676
+        sqlOperator = " IN ";
+        isMultiValued = true;
+        value = prepareParameterizedStringForList((List<Object>) value, paramsBuilder);
+        break;
+      case NOT_EXISTS:
+        sqlOperator = " IS NULL ";
+        value = null;
+        // For fields inside jsonb
+        StringBuilder notExists = prepareFieldAccessorExpr(fieldName);
+        if (notExists != null) {
+          filterString = notExists;
+        }
+        break;
+      case EXISTS:
+        sqlOperator = " IS NOT NULL ";
+        value = null;
+        // For fields inside jsonb
+        StringBuilder exists = prepareFieldAccessorExpr(fieldName);
+        if (exists != null) {
+          filterString = exists;
+        }
+        break;
+      case NEQ:
+        sqlOperator = " != ";
+        // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520
+        // The expected behaviour is to get all documents which either satisfy non equality
+        // condition
+        // or the key doesn't exist in them
+        // Semantics for handling if key not exists and if it exists, its value
+        // doesn't equal to the filter for Jsonb document will be done as:
+        // "document->key IS NULL OR document->key->> != value"
+        StringBuilder notEquals = prepareFieldAccessorExpr(fieldName);
+        // For fields inside jsonb
+        if (notEquals != null) {
+          filterString = notEquals.append(" IS NULL OR ").append(fullFieldName);
+        }
+        break;
+      case CONTAINS:
+        // TODO: Matches condition inside an array of documents
+      default:
+        throw new UnsupportedOperationException(UNSUPPORTED_QUERY_OPERATION);
+    }
+
+    filterString.append(sqlOperator);
+    if (value != null) {
+      if (isMultiValued) {
+        filterString.append(value);
+      } else {
+        filterString.append(QUESTION_MARK);
+        paramsBuilder.addObjectParam(value);
+      }
+    }
+    String filters = filterString.toString();
+    return filters;
+  }
+
+  static String parseCompositeFilter(Filter filter, Builder paramsBuilder) {
+    Filter.Op op = filter.getOp();
+    switch (op) {
+      case OR:
+        {
+          String childList =
+              Arrays.stream(filter.getChildFilters())
+                  .map(childFilter -> parseFilter(childFilter, paramsBuilder))
+                  .filter(str -> !StringUtils.isEmpty(str))
+                  .map(str -> "(" + str + ")")
+                  .collect(Collectors.joining(" OR "));
+          return !childList.isEmpty() ? childList : null;
+        }
+      case AND:
+        {
+          String childList =
+              Arrays.stream(filter.getChildFilters())
+                  .map(childFilter -> parseFilter(childFilter, paramsBuilder))
+                  .filter(str -> !StringUtils.isEmpty(str))
+                  .map(str -> "(" + str + ")")
+                  .collect(Collectors.joining(" AND "));
+          return !childList.isEmpty() ? childList : null;
+        }
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Query operation:%s not supported", op));
+    }
+  }
+
+  static String parseOrderBys(List<OrderBy> orderBys) {
+    return orderBys.stream()
+        .map(
+            orderBy ->
+                prepareFieldDataAccessorExpr(orderBy.getField())
+                    + " "
+                    + (orderBy.isAsc() ? "ASC" : "DESC"))
+        .filter(str -> !StringUtils.isEmpty(str))
+        .collect(Collectors.joining(" , "));
+  }
+
+  private static String prepareParameterizedStringForList(
+      List<Object> values, Params.Builder paramsBuilder) {
+    String collect =
+        values.stream()
+            .map(
+                val -> {
+                  paramsBuilder.addObjectParam(val);
+                  return QUESTION_MARK;
+                })
+            .collect(Collectors.joining(", "));
+    return "(" + collect + ")";
+  }
+
+  private static StringBuilder prepareFieldAccessorExpr(String fieldName) {
+    // Generate json field accessor statement
+    if (!OUTER_COLUMNS.contains(fieldName)) {
+      StringBuilder filterString = new StringBuilder(DOCUMENT);
+      String[] nestedFields = fieldName.split(DOC_PATH_SEPARATOR);
+      for (String nestedField : nestedFields) {
+        filterString.append(JSON_FIELD_ACCESSOR).append("'").append(nestedField).append("'");
+      }
+      return filterString;
+    }
+    // Field accessor is only applicable to jsonb fields, return null otherwise
+    return null;
+  }
+
+  /**
+   * Add field prefix for searching into json document based on postgres syntax, handles nested
+   * keys. Note: It doesn't handle array elements in json document. e.g SELECT * FROM TABLE where
+   * document ->> 'first' = 'name' and document -> 'address' ->> 'pin' = "00000"
+   */
+  private static String prepareFieldDataAccessorExpr(String fieldName) {
+    StringBuilder fieldPrefix = new StringBuilder(fieldName);
+    if (!OUTER_COLUMNS.contains(fieldName)) {
+      fieldPrefix = new StringBuilder(DOCUMENT);
+      String[] nestedFields = fieldName.split(DOC_PATH_SEPARATOR);
+      for (int i = 0; i < nestedFields.length - 1; i++) {
+        fieldPrefix.append(JSON_FIELD_ACCESSOR).append("'").append(nestedFields[i]).append("'");
+      }
+      fieldPrefix
+          .append(JSON_DATA_ACCESSOR)
+          .append("'")
+          .append(nestedFields[nestedFields.length - 1])
+          .append("'");
+    }
+    return fieldPrefix.toString();
+  }
+
+  private static String prepareCast(String field, Object value) {
+    String fmt = "CAST (%s AS %s)";
+
+    // handle the case if the value type is collection for filter operator - `IN`
+    // Currently, for `IN` operator, we are considering List collection, and it is fair
+    // assumption that all its value of the same types. Based on that and for consistency
+    // we will use CAST ( <field name> as <type> ) for all non string operator.
+    // Ref : https://github.com/hypertrace/document-store/pull/30#discussion_r571782575
+
+    if (value instanceof List<?> && ((List<Object>) value).size() > 0) {
+      List<Object> listValue = (List<Object>) value;
+      value = listValue.get(0);
+    }
+
+    if (value instanceof Number) {
+      return String.format(fmt, field, "NUMERIC");
+    } else if (value instanceof Boolean) {
+      return String.format(fmt, field, "BOOLEAN");
+    } else /* default is string */ {
+      return field;
+    }
+  }
+}

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -12,13 +12,9 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCursor;
 import java.util.List;
-import java.util.Map;
 import org.bson.conversions.Bson;
 import org.hypertrace.core.documentstore.Filter;
-import org.hypertrace.core.documentstore.Filter.Op;
-import org.hypertrace.core.documentstore.OrderBy;
 import org.hypertrace.core.documentstore.Query;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,135 +29,6 @@ public class MongoCollectionTest {
   public void setup() {
     collection = mock(com.mongodb.client.MongoCollection.class);
     mongoCollection = new MongoCollection(collection);
-  }
-
-  @Test
-  public void testParseSimpleQuery() {
-    {
-      Filter filter = new Filter(Filter.Op.EQ, "key1", "val1");
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals("val1", query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.GT, "key1", 5);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$gt", 5), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.GTE, "key1", 5);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$gte", 5), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.LT, "key1", 5);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$lt", 5), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.LTE, "key1", 5);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$lte", 5), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.EXISTS, "key1", null);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$exists", true), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$exists", false), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.LIKE, "key1", ".*abc");
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$regex", ".*abc").append("$options", "i"), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$in", List.of("abc", "xyz")), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$nin", List.of("abc", "xyz")), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.CONTAINS, "key1", "abc");
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      assertEquals(new BasicDBObject("$elemMatch", "abc"), query.get("key1"));
-    }
-
-    {
-      Filter filter = new Filter(Filter.Op.NEQ, "key1", "abc");
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      BasicDBObject notEquals = new BasicDBObject();
-      notEquals.append("$ne", "abc");
-      Assertions.assertEquals(notEquals, query.get("key1"));
-    }
-  }
-
-  @Test
-  public void testParseAndOrQuery() {
-    {
-      Filter filter =
-          new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
-
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      Assertions.assertTrue(query.get("$and") instanceof List);
-      Assertions.assertTrue(
-          ((List) query.get("$and"))
-              .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
-    }
-
-    {
-      Filter filter =
-          new Filter(Filter.Op.EQ, "key1", "val1").or(new Filter(Filter.Op.EQ, "key2", "val2"));
-
-      Map<String, Object> query = mongoCollection.parseQuery(filter);
-      Assertions.assertTrue(query.get("$or") instanceof List);
-      Assertions.assertTrue(
-          ((List) query.get("$or"))
-              .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
-    }
-  }
-
-  @Test
-  public void testParseNestedQuery() {
-    Filter filter1 =
-        new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
-
-    Filter filter2 =
-        new Filter(Filter.Op.EQ, "key3", "val3").and(new Filter(Filter.Op.EQ, "key4", "val4"));
-
-    Filter filter = filter1.or(filter2);
-    Map<String, Object> query = mongoCollection.parseQuery(filter);
-    assertEquals(2, ((List) query.get("$or")).size());
-    Assertions.assertTrue(
-        ((List) ((Map) ((List) query.get("$or")).get(0)).get("$and"))
-            .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
-    Assertions.assertTrue(
-        ((List) ((Map) ((List) query.get("$or")).get(1)).get("$and"))
-            .containsAll(List.of(Map.of("key3", "val3"), Map.of("key4", "val4"))));
-  }
-
-  @Test
-  public void testParseOrderByQuery() {
-    List<OrderBy> orderBys =
-        List.of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
-    assertEquals(
-        Map.of("key1", 1, "key2", -1, "key3", 1), mongoCollection.parseOrderByQuery(orderBys));
   }
 
   @Test

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -158,10 +158,10 @@ public class MongoCollectionTest {
 
   @Test
   public void testParseOrderByQuery() {
-    List<OrderBy> orderBys = List
-        .of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
-    assertEquals(Map.of("key1", 1, "key2", -1, "key3", 1),
-        mongoCollection.parseOrderByQuery(orderBys));
+    List<OrderBy> orderBys =
+        List.of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
+    assertEquals(
+        Map.of("key1", 1, "key2", -1, "key3", 1), mongoCollection.parseOrderByQuery(orderBys));
   }
 
   @Test

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.bson.conversions.Bson;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
+import org.hypertrace.core.documentstore.OrderBy;
 import org.hypertrace.core.documentstore.Query;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,6 +154,14 @@ public class MongoCollectionTest {
     Assertions.assertTrue(
         ((List) ((Map) ((List) query.get("$or")).get(1)).get("$and"))
             .containsAll(List.of(Map.of("key3", "val3"), Map.of("key4", "val4"))));
+  }
+
+  @Test
+  public void testParseOrderByQuery() {
+    List<OrderBy> orderBys = List
+        .of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
+    assertEquals(Map.of("key1", 1, "key2", -1, "key3", 1),
+        mongoCollection.parseOrderByQuery(orderBys));
   }
 
   @Test

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryParserTest.java
@@ -1,0 +1,144 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mongodb.BasicDBObject;
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.Filter.Op;
+import org.hypertrace.core.documentstore.OrderBy;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MongoQueryParserTest {
+
+  @Test
+  void testParseSimpleQuery() {
+    {
+      Filter filter = new Filter(Filter.Op.EQ, "key1", "val1");
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals("val1", query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.GT, "key1", 5);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$gt", 5), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.GTE, "key1", 5);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$gte", 5), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.LT, "key1", 5);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$lt", 5), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.LTE, "key1", 5);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$lte", 5), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.EXISTS, "key1", null);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$exists", true), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$exists", false), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.LIKE, "key1", ".*abc");
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$regex", ".*abc").append("$options", "i"), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$in", List.of("abc", "xyz")), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$nin", List.of("abc", "xyz")), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.CONTAINS, "key1", "abc");
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      assertEquals(new BasicDBObject("$elemMatch", "abc"), query.get("key1"));
+    }
+
+    {
+      Filter filter = new Filter(Filter.Op.NEQ, "key1", "abc");
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      BasicDBObject notEquals = new BasicDBObject();
+      notEquals.append("$ne", "abc");
+      Assertions.assertEquals(notEquals, query.get("key1"));
+    }
+  }
+
+  @Test
+  void testParseAndOrQuery() {
+    {
+      Filter filter =
+          new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
+
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      Assertions.assertTrue(query.get("$and") instanceof List);
+      Assertions.assertTrue(
+          ((List) query.get("$and"))
+              .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
+    }
+
+    {
+      Filter filter =
+          new Filter(Filter.Op.EQ, "key1", "val1").or(new Filter(Filter.Op.EQ, "key2", "val2"));
+
+      Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+      Assertions.assertTrue(query.get("$or") instanceof List);
+      Assertions.assertTrue(
+          ((List) query.get("$or"))
+              .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
+    }
+  }
+
+  @Test
+  void testParseNestedQuery() {
+    Filter filter1 =
+        new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
+
+    Filter filter2 =
+        new Filter(Filter.Op.EQ, "key3", "val3").and(new Filter(Filter.Op.EQ, "key4", "val4"));
+
+    Filter filter = filter1.or(filter2);
+    Map<String, Object> query = MongoQueryParser.parseFilter(filter);
+    assertEquals(2, ((List) query.get("$or")).size());
+    Assertions.assertTrue(
+        ((List) ((Map) ((List) query.get("$or")).get(0)).get("$and"))
+            .containsAll(List.of(Map.of("key1", "val1"), Map.of("key2", "val2"))));
+    Assertions.assertTrue(
+        ((List) ((Map) ((List) query.get("$or")).get(1)).get("$and"))
+            .containsAll(List.of(Map.of("key3", "val3"), Map.of("key4", "val4"))));
+  }
+
+  @Test
+  void testParseOrderByQuery() {
+    List<OrderBy> orderBys =
+        List.of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
+    assertEquals(
+        Map.of("key1", 1, "key2", -1, "key3", 1), MongoQueryParser.parseOrderBys(orderBys));
+  }
+}

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
@@ -1,190 +1,179 @@
 package org.hypertrace.core.documentstore.postgres;
 
+import static org.hypertrace.core.documentstore.Collection.UNSUPPORTED_QUERY_OPERATION;
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.CREATED_AT;
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOCUMENT_ID;
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.ID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
-import java.sql.Connection;
 import java.util.List;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PostgresCollectionTest {
-
-  private PostgresCollection collection;
-
-  @BeforeEach
-  public void setUp() {
-    String COLLECTION_NAME = "mytest";
-    Connection client = mock(Connection.class);
-    collection = new PostgresCollection(client, COLLECTION_NAME);
-  }
+class PostgresQueryParserTest {
 
   @Test
-  public void testParseNonCompositeFilter() {
+  void testParseNonCompositeFilter() {
     {
       Filter filter = new Filter(Filter.Op.EQ, ID, "val1");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals(ID + " = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NEQ, ID, "val1");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals(ID + " != ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GT, ID, 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) > ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GTE, ID, 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) >= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LT, ID, 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) < ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LTE, ID, 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) <= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LIKE, ID, "abc");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals(ID + " ILIKE ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.IN, ID, List.of("abc", "xyz"));
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals(ID + " IN (?, ?)", query);
     }
   }
 
   @Test
-  public void testParseNonCompositeFilterForJsonField() {
+  void testParseNonCompositeFilterForJsonField() {
     {
       Filter filter = new Filter(Filter.Op.EQ, "key1", "val1");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NEQ, "key1", "val1");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL OR document->>'key1' != ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GT, "key1", 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) > ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GTE, "key1", 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) >= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LT, "key1", 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) < ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LTE, "key1", 5);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) <= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LIKE, "key1", "abc");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' ILIKE ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' IN (?, ?)", query);
     }
 
     {
       Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL OR document->>'key1' NOT IN (?, ?)", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.EQ, DOCUMENT_ID, "k1:k2");
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->>'_id' = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.EXISTS, "key1.key2", null);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       System.err.println(query);
       Assertions.assertEquals("document->'key1'->'key2' IS NOT NULL ", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
-      String query = collection.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL ", query);
     }
   }
 
   @Test
-  public void testNonCompositeFilterUnsupportedException() {
-    String expectedMessage = collection.UNSUPPORTED_QUERY_OPERATION;
+  void testNonCompositeFilterUnsupportedException() {
+    String expectedMessage = UNSUPPORTED_QUERY_OPERATION;
     {
       Filter filter = new Filter(Filter.Op.CONTAINS, "key1", null);
       String expected = String.format(expectedMessage, Filter.Op.CONTAINS);
       Exception exception =
           assertThrows(
               UnsupportedOperationException.class,
-              () -> collection.parseNonCompositeFilter(filter, initParams()));
+              () -> PostgresQueryParser.parseNonCompositeFilter(filter, initParams()));
       String actualMessage = exception.getMessage();
       Assertions.assertTrue(actualMessage.contains(expected));
     }
   }
 
   @Test
-  public void testParseQueryForCompositeFilterWithNullConditions() {
+  void testParseQueryForCompositeFilterWithNullConditions() {
     {
       Filter filter = new Filter(Filter.Op.AND, null, null);
-      Assertions.assertNull(collection.parseFilter(filter, initParams()));
+      Assertions.assertNull(PostgresQueryParser.parseFilter(filter, initParams()));
     }
     {
       Filter filter = new Filter(Filter.Op.OR, null, null);
-      Assertions.assertNull(collection.parseFilter(filter, initParams()));
+      Assertions.assertNull(PostgresQueryParser.parseFilter(filter, initParams()));
     }
   }
 
   @Test
-  public void testParseQueryForCompositeFilter() {
+  void testParseQueryForCompositeFilter() {
     {
       Filter filter =
           new Filter(Filter.Op.EQ, ID, "val1").and(new Filter(Filter.Op.EQ, CREATED_AT, "val2"));
-      String query = collection.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
       Assertions.assertEquals(String.format("(%s = ?) AND (%s = ?)", ID, CREATED_AT), query);
     }
 
@@ -192,17 +181,17 @@ public class PostgresCollectionTest {
       Filter filter =
           new Filter(Filter.Op.EQ, ID, "val1").or(new Filter(Filter.Op.EQ, CREATED_AT, "val2"));
 
-      String query = collection.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
       Assertions.assertEquals(String.format("(%s = ?) OR (%s = ?)", ID, CREATED_AT), query);
     }
   }
 
   @Test
-  public void testParseQueryForCompositeFilterForJsonField() {
+  void testParseQueryForCompositeFilterForJsonField() {
     {
       Filter filter =
           new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
-      String query = collection.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
       Assertions.assertEquals("(document->>'key1' = ?) AND (document->>'key2' = ?)", query);
     }
 
@@ -210,13 +199,13 @@ public class PostgresCollectionTest {
       Filter filter =
           new Filter(Filter.Op.EQ, "key1", "val1").or(new Filter(Filter.Op.EQ, "key2", "val2"));
 
-      String query = collection.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
       Assertions.assertEquals("(document->>'key1' = ?) OR (document->>'key2' = ?)", query);
     }
   }
 
   @Test
-  public void testParseNestedQuery() {
+  void testParseNestedQuery() {
     Filter filter1 =
         new Filter(Filter.Op.EQ, ID, "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
 
@@ -224,7 +213,7 @@ public class PostgresCollectionTest {
         new Filter(Filter.Op.EQ, ID, "val3").and(new Filter(Filter.Op.EQ, "key4", "val4"));
 
     Filter filter = filter1.or(filter2);
-    String query = collection.parseFilter(filter, initParams());
+    String query = PostgresQueryParser.parseFilter(filter, initParams());
     Assertions.assertEquals(
         String.format(
             "((%s = ?) AND (document->>'key2' = ?)) " + "OR ((%s = ?) AND (document->>'key4' = ?))",
@@ -233,7 +222,7 @@ public class PostgresCollectionTest {
   }
 
   @Test
-  public void testJSONFieldParseNestedQuery() {
+  void testJSONFieldParseNestedQuery() {
     Filter filter1 =
         new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
 
@@ -241,7 +230,7 @@ public class PostgresCollectionTest {
         new Filter(Filter.Op.EQ, "key3", "val3").and(new Filter(Filter.Op.EQ, "key4", "val4"));
 
     Filter filter = filter1.or(filter2);
-    String query = collection.parseFilter(filter, initParams());
+    String query = PostgresQueryParser.parseFilter(filter, initParams());
     Assertions.assertEquals(
         "((document->>'key1' = ?) AND (document->>'key2' = ?)) "
             + "OR ((document->>'key3' = ?) AND (document->>'key4' = ?))",

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
+import org.hypertrace.core.documentstore.OrderBy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -235,6 +236,15 @@ class PostgresQueryParserTest {
         "((document->>'key1' = ?) AND (document->>'key2' = ?)) "
             + "OR ((document->>'key3' = ?) AND (document->>'key4' = ?))",
         query);
+  }
+
+  @Test
+  void testParseOrderBys() {
+    List<OrderBy> orderBys =
+        List.of(new OrderBy("key1", true), new OrderBy("key2", false), new OrderBy("key3", true));
+    Assertions.assertEquals(
+        "document->>'key1' ASC , document->>'key2' DESC , document->>'key3' ASC",
+        PostgresQueryParser.parseOrderBys(orderBys));
   }
 
   private Params.Builder initParams() {


### PR DESCRIPTION
## Description
Fixes https://github.com/hypertrace/document-store/issues/50 by using `LinkedHashMap` instead of `HashMap` for `orderByMap` to preserve the order of keys (as in the list).

### Testing
Added unit test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules