### PR TITLE
fix: postgres iterator interface to handle any order

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -1237,7 +1237,7 @@ public class DocStoreTest {
       query.setFilter(new Filter(Filter.Op.EQ, "_id", key1.toString()));
       Iterator<Document> results = collection.search(query);
       if (!results.hasNext()) {
-        Assertions.assertFalse(false);
+        Assertions.fail();
       }
       List<Document> documents = new ArrayList<>();
       while (results.hasNext()) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -493,7 +493,7 @@ public class PostgresCollection implements Collection {
 
     private final ObjectMapper MAPPER = new ObjectMapper();
     private ResultSet resultSet;
-    private boolean didNext = false;
+    private boolean cursorMovedForward = false;
     private boolean hasNext = false;
 
     public PostgresResultIterator(ResultSet resultSet) {
@@ -503,9 +503,9 @@ public class PostgresCollection implements Collection {
     @Override
     public boolean hasNext() {
       try {
-        if (!didNext) {
+        if (!cursorMovedForward) {
           hasNext = resultSet.next();
-          didNext = true;
+          cursorMovedForward = true;
         }
         return hasNext;
       } catch (SQLException e) {
@@ -517,10 +517,11 @@ public class PostgresCollection implements Collection {
     @Override
     public Document next() {
       try {
-        if (!didNext) {
+        if (!cursorMovedForward) {
           resultSet.next();
         }
-        didNext = false;
+        // reset the cursorMovedForward state, if it was forwarded in hasNext.
+        cursorMovedForward = false;
         return prepareDocument();
       } catch (IOException | SQLException e) {
         return JSONDocument.errorDocument(e.getMessage());

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore.postgres;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
@@ -491,7 +492,9 @@ public class PostgresCollection implements Collection {
   static class PostgresResultIterator implements Iterator {
 
     private final ObjectMapper MAPPER = new ObjectMapper();
-    ResultSet resultSet;
+    private ResultSet resultSet;
+    private boolean didNext = false;
+    private boolean hasNext = false;
 
     public PostgresResultIterator(ResultSet resultSet) {
       this.resultSet = resultSet;
@@ -500,7 +503,11 @@ public class PostgresCollection implements Collection {
     @Override
     public boolean hasNext() {
       try {
-        return resultSet.next();
+        if (!didNext) {
+          hasNext = resultSet.next();
+          didNext = true;
+        }
+        return hasNext;
       } catch (SQLException e) {
         LOGGER.error("SQLException iterating documents.", e);
       }
@@ -510,19 +517,27 @@ public class PostgresCollection implements Collection {
     @Override
     public Document next() {
       try {
-        String documentString = resultSet.getString(DOCUMENT);
-        ObjectNode jsonNode = (ObjectNode) MAPPER.readTree(documentString);
-        jsonNode.remove(DOCUMENT_ID);
-        // Add Timestamps to Document
-        Timestamp createdAt = resultSet.getTimestamp(CREATED_AT);
-        Timestamp updatedAt = resultSet.getTimestamp(UPDATED_AT);
-        jsonNode.put(CREATED_AT, String.valueOf(createdAt));
-        jsonNode.put(UPDATED_AT, String.valueOf(updatedAt));
-
-        return new JSONDocument(MAPPER.writeValueAsString(jsonNode));
+        if (!didNext) {
+          resultSet.next();
+        }
+        didNext = false;
+        return prepareDocument();
       } catch (IOException | SQLException e) {
         return JSONDocument.errorDocument(e.getMessage());
       }
+    }
+
+    private Document prepareDocument() throws SQLException, JsonProcessingException, IOException {
+      String documentString = resultSet.getString(DOCUMENT);
+      ObjectNode jsonNode = (ObjectNode) MAPPER.readTree(documentString);
+      jsonNode.remove(DOCUMENT_ID);
+      // Add Timestamps to Document
+      Timestamp createdAt = resultSet.getTimestamp(CREATED_AT);
+      Timestamp updatedAt = resultSet.getTimestamp(UPDATED_AT);
+      jsonNode.put(CREATED_AT, String.valueOf(createdAt));
+      jsonNode.put(UPDATED_AT, String.valueOf(updatedAt));
+
+      return new JSONDocument(MAPPER.writeValueAsString(jsonNode));
     }
 
     private String prepareNumericBlock(String fieldName, Object value) {


### PR DESCRIPTION
## Description
Fix for the issue - https://github.com/hypertrace/hypertrace/issues/248

As recently, we have added support for time-agnostic API support and the corresponding GraphQL query was failing.

```
{
  entities(
    type: SERVICE
    limit: 1
    between: {startTime: "2021-06-01T14:59:41.614Z", endTime: "2021-06-01T15:59:41.614Z"}
    filterBy: [{operator: EQUALS, value: "b89ddf9b-c582-3d93-9006-a4b3024cf5a5", type: ID, idType: SERVICE}]
    includeInactive: true
  ) {
    results {
      id
      name: attribute(key: "name")
      __typename
    }
    __typename
  }
}
```

As the flag `includeInactive: true` along with attribute data source, triggers different workflow for fetching from the document store ( mongo/postgres) or OLAP store. In the previous release, it was fetched from pinot. But, in the latest release, it is fetched from the document store. 

There is a bug in Postgres hasNext interface implementation which assumes a fixed order of fetch as pattern `[hasNext, next, hasNext, next]`. However, a client can call in any order like `[hasNext, hasNext, next]` that is the exact thing happening in the new flow (EntityQueryServiceImpl at [first](https://github.com/hypertrace/entity-service/blob/f8151b08d3a2e35f9ad3e91b9a26774378cc0cae/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java#L113) hasNext and [second](https://github.com/hypertrace/entity-service/blob/f8151b08d3a2e35f9ad3e91b9a26774378cc0cae/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java#L125) hasNext). 

The below PR fix the issue. As `isLast` and other ResultSet API are costly, we are fixing them at our end

### Testing
- Added integration test.
- verified locally with docker-compose setup

output:
<img width="1668" alt="Screenshot 2021-06-01 at 6 02 23 PM" src="https://user-images.githubusercontent.com/53209990/120441477-38ccdb80-c3a2-11eb-8f9d-82e51da62fac.png">


### Checklist:
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

