### PR TITLE
Add support for group by with implementation for MongoDB

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 
 dependencies {
   api("com.typesafe:config:1.3.2")
+  annotationProcessor("org.projectlombok:lombok:1.18.22")
+  implementation("org.projectlombok:lombok:1.18.22")
   implementation("org.postgresql:postgresql:42.2.13")
   implementation("org.mongodb:mongodb-driver-sync:4.1.2")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
@@ -15,6 +17,9 @@ dependencies {
   implementation("com.google.guava:guava-annotations:r03")
   implementation("org.apache.commons:commons-lang3:3.10")
   implementation("net.jodah:failsafe:2.4.0")
+
+  testAnnotationProcessor("org.projectlombok:lombok:1.18.22")
+  testImplementation("org.projectlombok:lombok:1.18.22")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.0")
   testImplementation("org.mockito:mockito-core:2.19.0")

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -63,6 +63,14 @@ public interface Collection {
   Iterator<Document> search(Query query);
 
   /**
+   * Aggregate documents matching the query
+   *
+   * @param query aggregation specification to collect matching documents
+   * @return {@link Iterator} of aggregated matching documents
+   */
+  Iterator<Document> aggregate(Query query);
+
+  /**
    * Delete the document with the given key.
    *
    * @param key The {@link Key} of the document to be deleted.

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/GroupBy.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/GroupBy.java
@@ -1,0 +1,32 @@
+package org.hypertrace.core.documentstore;
+
+import java.util.List;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.documentstore.expression.Expression;
+
+@Data
+public class GroupBy {
+  private Expression key; // The key field whose distinct values would be returned
+  private List<GroupingSpec> groupingSpecs; // The list of aggregations required
+
+  public enum Accumulator {
+    FIRST,
+    LAST,
+    MIN,
+    MAX,
+    COUNT,
+    SUM,
+    AVERAGE,
+  }
+
+  @Override
+  public String toString() {
+    return "GroupBy{"
+        + "key="
+        + key
+        + ", groupingSpecs="
+        + StringUtils.join(groupingSpecs, ",")
+        + '}';
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/GroupingSpec.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/GroupingSpec.java
@@ -1,0 +1,20 @@
+package org.hypertrace.core.documentstore;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.hypertrace.core.documentstore.expression.Expression;
+
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class GroupingSpec {
+  private Expression expression; // The expression to be grouped
+  private GroupBy.Accumulator accumulator; // The accumulator function
+  private String alias; // Name of the accumulation result
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s) AS %s", accumulator.name(), expression.toString(), alias);
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Query.java
@@ -5,13 +5,13 @@ import java.util.List;
 import java.util.Objects;
 
 public class Query {
-
-  // support only filter for now. Add aggregations and group by later.
   private final List<String> selections = new ArrayList<>();
   private Filter filter;
   private final List<OrderBy> orderBys = new ArrayList<>();
   private Integer offset;
   private Integer limit;
+  private GroupBy groupBy;
+  private Filter groupingFilter; // Similar to HAVING clause in SQL
 
   public void addAllSelections(List<String> selections) {
     this.selections.addAll(selections);
@@ -61,6 +61,22 @@ public class Query {
     this.limit = limit;
   }
 
+  public GroupBy getGroupBy() {
+    return groupBy;
+  }
+
+  public void setGroupBy(GroupBy groupBy) {
+    this.groupBy = groupBy;
+  }
+
+  public Filter getGroupingFilter() {
+    return groupingFilter;
+  }
+
+  public void setGroupingFilter(Filter groupingFilter) {
+    this.groupingFilter = groupingFilter;
+  }
+
   @Override
   public String toString() {
     return "Query{"
@@ -70,6 +86,10 @@ public class Query {
         + filter
         + ", orderBys="
         + orderBys
+        + ", groupBy="
+        + groupBy
+        + ", groupingFilter="
+        + groupingFilter
         + ", offset="
         + offset
         + ", limit="
@@ -85,12 +105,14 @@ public class Query {
     return Objects.equals(selections, query.selections)
         && Objects.equals(filter, query.filter)
         && Objects.equals(orderBys, query.orderBys)
+        && Objects.equals(groupBy, query.groupBy)
+        && Objects.equals(groupingFilter, query.groupingFilter)
         && Objects.equals(offset, query.offset)
         && Objects.equals(limit, query.limit);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(selections, filter, orderBys, offset, limit);
+    return Objects.hash(selections, filter, orderBys, groupBy, groupingFilter, offset, limit);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/BinaryOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/BinaryOperator.java
@@ -1,0 +1,11 @@
+package org.hypertrace.core.documentstore.expression;
+
+public enum BinaryOperator {
+  ADD,
+  SUBTRACT,
+  MULTIPLY,
+  DIVIDE,
+  REMINDER,
+  LOG,
+  POWER,
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/BinaryOperatorExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/BinaryOperatorExpression.java
@@ -1,0 +1,19 @@
+package org.hypertrace.core.documentstore.expression;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class BinaryOperatorExpression implements OperatorExpression {
+  private Expression operand1; // Operand on the left side of the expression
+  private BinaryOperator operation;
+  private Expression operand2; // Operand on the right side of the expression
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s, %s)", operation.name(), operand1.toString(), operand2.toString());
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/Expression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/Expression.java
@@ -1,0 +1,3 @@
+package org.hypertrace.core.documentstore.expression;
+
+public interface Expression {}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/LiteralExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/LiteralExpression.java
@@ -1,0 +1,17 @@
+package org.hypertrace.core.documentstore.expression;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class LiteralExpression implements Expression {
+  private String literal;
+
+  @Override
+  public String toString() {
+    return literal;
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/OperatorExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/OperatorExpression.java
@@ -1,0 +1,3 @@
+package org.hypertrace.core.documentstore.expression;
+
+public interface OperatorExpression extends Expression {}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/UnaryOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/UnaryOperator.java
@@ -1,0 +1,11 @@
+package org.hypertrace.core.documentstore.expression;
+
+public enum UnaryOperator {
+  ABS,
+  FLOOR,
+  CEIL,
+  ROUND,
+  LN,
+  LOG10,
+  SQRT,
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/UnaryOperatorExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/UnaryOperatorExpression.java
@@ -1,0 +1,18 @@
+package org.hypertrace.core.documentstore.expression;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class UnaryOperatorExpression implements OperatorExpression {
+  private Expression operand;
+  private UnaryOperator operation;
+
+  @Override
+  public String toString() {
+    return String.format("%s(%s)", operation, operand.toString());
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoBinaryOperatorExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoBinaryOperatorExpressionParser.java
@@ -1,0 +1,22 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.hypertrace.core.documentstore.expression.BinaryOperatorExpression;
+
+// Ref.: https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#operator-expressions
+public class MongoBinaryOperatorExpressionParser
+    implements MongoExpressionParser<BinaryOperatorExpression> {
+  @Override
+  public LinkedHashMap<String, Object> parseExpression(BinaryOperatorExpression expression) {
+    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+    List<Object> operands =
+        Arrays.asList(
+            MongoQueryParser.parseExpression(expression.getOperand1()),
+            MongoQueryParser.parseExpression(expression.getOperand2()));
+
+    map.put("$" + expression.getOperation().name().toLowerCase(), operands);
+    return map;
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoExpressionParser.java
@@ -1,0 +1,7 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import org.hypertrace.core.documentstore.expression.Expression;
+
+public interface MongoExpressionParser<T extends Expression> {
+  Object parseExpression(T expression);
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoLiteralExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoLiteralExpressionParser.java
@@ -1,0 +1,10 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import org.hypertrace.core.documentstore.expression.LiteralExpression;
+
+public class MongoLiteralExpressionParser implements MongoExpressionParser<LiteralExpression> {
+  @Override
+  public String parseExpression(LiteralExpression expression) {
+    return expression.getLiteral();
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoUnaryOperatorExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoUnaryOperatorExpressionParser.java
@@ -1,0 +1,17 @@
+package org.hypertrace.core.documentstore.mongo;
+
+import java.util.LinkedHashMap;
+import org.hypertrace.core.documentstore.expression.UnaryOperatorExpression;
+
+// Ref.: https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#operator-expressions
+public class MongoUnaryOperatorExpressionParser
+    implements MongoExpressionParser<UnaryOperatorExpression> {
+  @Override
+  public LinkedHashMap<String, Object> parseExpression(UnaryOperatorExpression expression) {
+    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+    map.put(
+        "$" + expression.getOperation().name().toLowerCase(),
+        MongoQueryParser.parseExpression(expression.getOperand()));
+    return map;
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -275,6 +275,11 @@ public class PostgresCollection implements Collection {
     return Collections.emptyIterator();
   }
 
+  @Override
+  public Iterator<Document> aggregate(Query query) {
+    throw new UnsupportedOperationException();
+  }
+
   @VisibleForTesting
   protected PreparedStatement buildPreparedStatement(String sqlQuery, Params params)
       throws SQLException, RuntimeException {


### PR DESCRIPTION
## Description
Draft changes to add group by support in document store.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
