### PR TITLE
Modified hibernate-validator code and dependency to avoid exception in consumers.

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
 
 dependencies {
   api("com.typesafe:config:1.3.2")
+  api("org.hibernate:hibernate-validator:6.1.3.Final")
+  api("org.glassfish:javax.el:3.0.1-b06")
+  api("javax.el:javax.el-api:3.0.1-b06")
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.22")
-  implementation("org.hibernate:hibernate-validator:6.1.3.Final")
   implementation("org.apache.commons:commons-collections4:4.4")
-  implementation("org.glassfish:javax.el:3.0.1-b06")
   implementation("org.postgresql:postgresql:42.2.13")
   implementation("org.mongodb:mongodb-driver-sync:4.1.2")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/Utils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/Utils.java
@@ -4,11 +4,16 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 public class Utils {
 
   private static final Validator validator =
-      Validation.buildDefaultValidatorFactory().getValidator();
+      Validation.byDefaultProvider()
+          .configure()
+          .messageInterpolator(new ParameterMessageInterpolator())
+          .buildValidatorFactory()
+          .getValidator();
 
   public static <T> T validateAndReturn(final T expression) {
     Set<ConstraintViolation<T>> exceptions = validator.validate(expression);


### PR DESCRIPTION
Having this module as dependency in callers sometimes results in `javax.validation.ValidationException: HV000183`
Modified the code and the dependencies in an attempt to avoid this