### PR TITLE
Handling duplicate selections in MongoDB

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   implementation("org.apache.commons:commons-collections4:4.4")
   implementation("org.postgresql:postgresql:42.2.13")
   implementation("org.mongodb:mongodb-driver-sync:4.1.2")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.6")
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("com.google.guava:guava-annotations:r03")
   implementation("org.apache.commons:commons-lang3:3.10")

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -128,6 +128,32 @@ public class MongoQueryExecutorIntegrationTest {
   }
 
   @Test
+  public void testFindWithDuplicateSelections() throws IOException {
+    List<SelectionSpec> selectionSpecs =
+        List.of(
+            SelectionSpec.of(IdentifierExpression.of("item")),
+            SelectionSpec.of(IdentifierExpression.of("item")),
+            SelectionSpec.of(IdentifierExpression.of("price")),
+            SelectionSpec.of(IdentifierExpression.of("quantity")),
+            SelectionSpec.of(IdentifierExpression.of("quantity")),
+            SelectionSpec.of(IdentifierExpression.of("date")));
+    Selection selection = Selection.builder().selectionSpecs(selectionSpecs).build();
+    Filter filter =
+        Filter.builder()
+            .expression(
+                RelationalExpression.of(
+                    IdentifierExpression.of("item"),
+                    NOT_IN,
+                    ConstantExpression.ofStrings(List.of("Soap", "Bottle"))))
+            .build();
+
+    Query query = Query.builder().setSelection(selection).setFilter(filter).build();
+
+    Iterator<Document> resultDocs = collection.find(query);
+    assertDocsEqual(resultDocs, "mongo/simple_filter_response.json");
+  }
+
+  @Test
   public void testFindWithSortingAndPagination() throws IOException {
     List<SelectionSpec> selectionSpecs =
         List.of(
@@ -148,6 +174,47 @@ public class MongoQueryExecutorIntegrationTest {
 
     Sort sort =
         Sort.builder()
+            .sortingSpec(SortingSpec.of(IdentifierExpression.of("quantity"), DESC))
+            .sortingSpec(SortingSpec.of(IdentifierExpression.of("item"), ASC))
+            .build();
+
+    Pagination pagination = Pagination.builder().offset(1).limit(3).build();
+
+    Query query =
+        Query.builder()
+            .setSelection(selection)
+            .setFilter(filter)
+            .setSort(sort)
+            .setPagination(pagination)
+            .build();
+
+    Iterator<Document> resultDocs = collection.find(query);
+    assertDocsEqual(resultDocs, "mongo/filter_with_sorting_and_pagination_response.json");
+  }
+
+  @Test
+  public void testFindWithDuplicateSortingAndPagination() throws IOException {
+    List<SelectionSpec> selectionSpecs =
+        List.of(
+            SelectionSpec.of(IdentifierExpression.of("item")),
+            SelectionSpec.of(IdentifierExpression.of("price")),
+            SelectionSpec.of(IdentifierExpression.of("quantity")),
+            SelectionSpec.of(IdentifierExpression.of("date")));
+    Selection selection = Selection.builder().selectionSpecs(selectionSpecs).build();
+
+    Filter filter =
+        Filter.builder()
+            .expression(
+                RelationalExpression.of(
+                    IdentifierExpression.of("item"),
+                    IN,
+                    ConstantExpression.ofStrings(List.of("Mirror", "Comb", "Shampoo", "Bottle"))))
+            .build();
+
+    Sort sort =
+        Sort.builder()
+            .sortingSpec(SortingSpec.of(IdentifierExpression.of("quantity"), DESC))
+            .sortingSpec(SortingSpec.of(IdentifierExpression.of("item"), ASC))
             .sortingSpec(SortingSpec.of(IdentifierExpression.of("quantity"), DESC))
             .sortingSpec(SortingSpec.of(IdentifierExpression.of("item"), ASC))
             .build();
@@ -222,6 +289,18 @@ public class MongoQueryExecutorIntegrationTest {
   }
 
   @Test
+  public void testAggregateWithDuplicateSelections() throws IOException {
+    Query query =
+        Query.builder()
+            .addSelection(AggregateExpression.of(COUNT, IdentifierExpression.of("item")), "count")
+            .addSelection(AggregateExpression.of(COUNT, IdentifierExpression.of("item")), "count")
+            .build();
+
+    Iterator<Document> resultDocs = collection.aggregate(query);
+    assertDocsEqual(resultDocs, "mongo/count_response.json");
+  }
+
+  @Test
   public void testAggregateWithFiltersAndOrdering() throws IOException {
     Query query =
         Query.builder()
@@ -236,6 +315,44 @@ public class MongoQueryExecutorIntegrationTest {
                 "total")
             .addSelection(IdentifierExpression.of("item"))
             .addAggregation(IdentifierExpression.of("item"))
+            .addSort(IdentifierExpression.of("total"), DESC)
+            .setAggregationFilter(
+                LogicalExpression.builder()
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("total"), GTE, ConstantExpression.of(11)))
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("total"), LTE, ConstantExpression.of(99)))
+                    .build())
+            .setFilter(
+                RelationalExpression.of(
+                    IdentifierExpression.of("quantity"), NEQ, ConstantExpression.of(10)))
+            .setPagination(Pagination.builder().limit(10).offset(0).build())
+            .build();
+
+    Iterator<Document> resultDocs = collection.aggregate(query);
+    assertDocsEqual(resultDocs, "mongo/sum_response.json");
+  }
+
+  @Test
+  public void testAggregateWithFiltersAndDuplicateOrderingAndDuplicateAggregations() throws IOException {
+    Query query =
+        Query.builder()
+            .addSelection(
+                AggregateExpression.of(
+                    SUM,
+                    FunctionExpression.builder()
+                        .operand(IdentifierExpression.of("price"))
+                        .operator(MULTIPLY)
+                        .operand(IdentifierExpression.of("quantity"))
+                        .build()),
+                "total")
+            .addSelection(IdentifierExpression.of("item"))
+            .addAggregation(IdentifierExpression.of("item"))
+            .addAggregation(IdentifierExpression.of("item"))
+            .addSort(IdentifierExpression.of("total"), DESC)
             .addSort(IdentifierExpression.of("total"), DESC)
             .setAggregationFilter(
                 LogicalExpression.builder()

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -337,7 +337,8 @@ public class MongoQueryExecutorIntegrationTest {
   }
 
   @Test
-  public void testAggregateWithFiltersAndDuplicateOrderingAndDuplicateAggregations() throws IOException {
+  public void testAggregateWithFiltersAndDuplicateOrderingAndDuplicateAggregations()
+      throws IOException {
     Query query =
         Query.builder()
             .addSelection(

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
@@ -89,6 +89,8 @@ public abstract class MongoSelectingExpressionParser implements SelectingExpress
       return second;
     }
 
-    throw new IllegalArgumentException("Query contains duplicate aliases");
+    throw new IllegalArgumentException(
+        String.format(
+            "Query contains duplicate aliases with different selections: (%s, %s)", first, second));
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
@@ -57,7 +57,11 @@ public abstract class MongoSelectingExpressionParser implements SelectingExpress
         selectionSpecs.stream()
             .map(spec -> MongoSelectingExpressionParser.parse(parser, spec))
             .flatMap(map -> map.entrySet().stream())
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, MongoSelectingExpressionParser::mergeValues));
+            .collect(
+                toMap(
+                    Map.Entry::getKey,
+                    Map.Entry::getValue,
+                    MongoSelectingExpressionParser::mergeValues));
 
     return new BasicDBObject(projectionMap);
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoSelectingExpressionParser.java
@@ -57,7 +57,7 @@ public abstract class MongoSelectingExpressionParser implements SelectingExpress
         selectionSpecs.stream()
             .map(spec -> MongoSelectingExpressionParser.parse(parser, spec))
             .flatMap(map -> map.entrySet().stream())
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, MongoSelectingExpressionParser::mergeValues));
 
     return new BasicDBObject(projectionMap);
   }
@@ -78,5 +78,13 @@ public abstract class MongoSelectingExpressionParser implements SelectingExpress
         new MongoProjectionSelectingExpressionParser(spec.getAlias(), baseParser);
 
     return spec.getExpression().visit(parser);
+  }
+
+  private static <T> T mergeValues(final T first, final T second) {
+    if (first.equals(second)) {
+      return second;
+    }
+
+    throw new IllegalArgumentException("Query contains duplicate aliases");
   }
 }


### PR DESCRIPTION
Handle duplications using
(i) a overwrite strategy for duplicate selections
(ii) an error-out strategy for duplicate aliases

## Description
Duplicate selections were causing a problem. This PR is to fix the issue.

### Testing
Added necessary unit and integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
