### PR TITLE
Encode alias so that they can contain special characters like dot

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -379,13 +379,14 @@ public class MongoQueryExecutorIntegrationTest {
   public void testAggregateWithNestedFields() throws IOException {
     Query query =
         Query.builder()
-            .addSelection(IdentifierExpression.of("props.seller.address.pincode"), "pincode")
-            .addSelection(AggregateExpression.of(SUM, ConstantExpression.of(1)), "num_items")
+            .addSelection(IdentifierExpression.of("props.seller.address.pincode"), "pincode.value")
+            .addSelection(AggregateExpression.of(SUM, ConstantExpression.of(1)), "num_items.value")
             .addAggregation(IdentifierExpression.of("props.seller.address.pincode"))
-            .addSort(IdentifierExpression.of("pincode"), DESC)
+            .addSort(IdentifierExpression.of("num_items.value"), DESC)
+            .addSort(IdentifierExpression.of("pincode.value"), DESC)
             .setAggregationFilter(
                 RelationalExpression.of(
-                    IdentifierExpression.of("num_items"), GT, ConstantExpression.of(1)))
+                    IdentifierExpression.of("num_items.value"), GT, ConstantExpression.of(1)))
             .build();
 
     Iterator<Document> resultDocs = collection.aggregate(query);

--- a/document-store/src/integrationTest/resources/mongo/aggregate_on_nested_fields_response.json
+++ b/document-store/src/integrationTest/resources/mongo/aggregate_on_nested_fields_response.json
@@ -1,14 +1,26 @@
 [
   {
-    "pincode": 700007,
-    "num_items": 2
+    "pincode": {
+      "value": null
+    },
+    "num_items": {
+      "value": 4
+    }
   },
   {
-    "pincode": 400004,
-    "num_items": 2
+    "pincode": {
+      "value": 700007
+    },
+    "num_items": {
+      "value": 2
+    }
   },
   {
-    "pincode": null,
-    "num_items": 4
+    "pincode": {
+      "value": 400004
+    },
+    "num_items": {
+      "value": 2
+    }
   }
 ]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoUtils.java
@@ -9,11 +9,19 @@ public final class MongoUtils {
     return new UnsupportedOperationException(String.format(UNSUPPORTED_OPERATION, t));
   }
 
-  public static String encodeKey(String key) {
+  public static String encodeKey(final String key) {
+    if (key == null) {
+      return null;
+    }
+
     return key.replace("\\", "\\\\").replace(PREFIX, "\\u0024").replace(FIELD_SEPARATOR, "\\u002e");
   }
 
-  public static String decodeKey(String key) {
+  public static String decodeKey(final String key) {
+    if (key == null) {
+      return null;
+    }
+
     return key.replace("\\u002e", FIELD_SEPARATOR).replace("\\u0024", PREFIX).replace("\\\\", "\\");
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoProjectionSelectingExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoProjectionSelectingExpressionParser.java
@@ -10,6 +10,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.type.SelectingExpression;
+import org.hypertrace.core.documentstore.mongo.MongoUtils;
 
 @Slf4j
 public final class MongoProjectionSelectingExpressionParser extends MongoSelectingExpressionParser {
@@ -64,6 +65,7 @@ public final class MongoProjectionSelectingExpressionParser extends MongoSelecti
 
     if (StringUtils.isBlank(alias)) {
       String key = StringUtils.stripStart(parsed.toString(), PREFIX);
+      key = MongoUtils.encodeKey(key);
       return Map.of(key, 1);
     }
 
@@ -86,6 +88,6 @@ public final class MongoProjectionSelectingExpressionParser extends MongoSelecti
           String.format("Alias is must for: %s", expression.toString()));
     }
 
-    return alias;
+    return MongoUtils.encodeKey(alias);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoProjectionSelectingExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoProjectionSelectingExpressionParser.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.documentstore.mongo.parser;
 
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.PREFIX;
+import static org.hypertrace.core.documentstore.mongo.MongoUtils.encodeKey;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +11,6 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.type.SelectingExpression;
-import org.hypertrace.core.documentstore.mongo.MongoUtils;
 
 @Slf4j
 public final class MongoProjectionSelectingExpressionParser extends MongoSelectingExpressionParser {
@@ -25,37 +25,7 @@ public final class MongoProjectionSelectingExpressionParser extends MongoSelecti
   @SuppressWarnings("unchecked")
   @Override
   public Map<String, Object> visit(final AggregateExpression expression) {
-    try {
-      return convertToMap(baseParser.visit(expression), expression);
-    } catch (UnsupportedOperationException e) {
-      return Map.of();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public Map<String, Object> visit(final ConstantExpression expression) {
-    try {
-      return convertToMap(baseParser.visit(expression), expression);
-    } catch (UnsupportedOperationException e) {
-      return Map.of();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public Map<String, Object> visit(final FunctionExpression expression) {
-    try {
-      return convertToMap(baseParser.visit(expression), expression);
-    } catch (UnsupportedOperationException e) {
-      return Map.of();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public Map<String, Object> visit(final IdentifierExpression expression) {
-    Object parsed;
+    final Object parsed;
 
     try {
       parsed = baseParser.visit(expression);
@@ -63,23 +33,68 @@ public final class MongoProjectionSelectingExpressionParser extends MongoSelecti
       return Map.of();
     }
 
-    if (StringUtils.isBlank(alias)) {
-      String key = StringUtils.stripStart(parsed.toString(), PREFIX);
-      key = MongoUtils.encodeKey(key);
-      return Map.of(key, 1);
-    }
-
-    return Map.of(alias, parsed);
+    final String key = getEncodedAlias(expression);
+    return convertToMap(key, parsed);
   }
 
-  private Map<String, Object> convertToMap(
-      final Object parsed, final SelectingExpression expression) {
-    if (parsed == null) {
+  @SuppressWarnings("unchecked")
+  @Override
+  public Map<String, Object> visit(final ConstantExpression expression) {
+    final Object parsed;
+
+    try {
+      parsed = baseParser.visit(expression);
+    } catch (UnsupportedOperationException e) {
       return Map.of();
     }
 
-    String key = getAlias(expression);
-    return Map.of(key, parsed);
+    final String key = getAlias(expression);
+    return convertToMap(key, parsed);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Map<String, Object> visit(final FunctionExpression expression) {
+    final Object parsed;
+
+    try {
+      parsed = baseParser.visit(expression);
+    } catch (UnsupportedOperationException e) {
+      return Map.of();
+    }
+
+    final String key = getEncodedAlias(expression);
+    return convertToMap(key, parsed);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Map<String, Object> visit(final IdentifierExpression expression) {
+    final String parsed;
+
+    try {
+      parsed = baseParser.visit(expression);
+    } catch (UnsupportedOperationException e) {
+      return Map.of();
+    }
+
+    final String key;
+
+    if (StringUtils.isBlank(alias)) {
+      key = StringUtils.stripStart(parsed, PREFIX);
+      return convertToMap(key, 1);
+    }
+
+    key = getAlias(expression);
+    return convertToMap(key, parsed);
+  }
+
+  private Map<String, Object> convertToMap(final String key, final Object parsed) {
+    return parsed == null ? Map.of() : Map.of(key, parsed);
+  }
+
+  private String getEncodedAlias(final SelectingExpression expression) {
+    return encodeKey(getAlias(expression));
   }
 
   private String getAlias(final SelectingExpression expression) {
@@ -88,6 +103,6 @@ public final class MongoProjectionSelectingExpressionParser extends MongoSelecti
           String.format("Alias is must for: %s", expression.toString()));
     }
 
-    return MongoUtils.encodeKey(alias);
+    return alias;
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorTest.java
@@ -314,7 +314,7 @@ class MongoQueryExecutorTest {
                     + "     }"
                     + "   }"
                     + "}"),
-            BasicDBObject.parse("{" + "\"$project\": {" + "    \"total\": 1" + "}" + "}"));
+            BasicDBObject.parse("{" + "\"$project\": {" + "    \"total\": \"$total\"" + "}" + "}"));
 
     testAggregation(query, pipeline);
   }
@@ -347,7 +347,7 @@ class MongoQueryExecutorTest {
                     + "\"$project\": "
                     + "   {"
                     + "     name: 1,"
-                    + "     total: 1"
+                    + "     total: \"$total\""
                     + "   }"
                     + "}"));
 
@@ -378,7 +378,8 @@ class MongoQueryExecutorTest {
                     + "     }"
                     + "   }"
                     + "}"),
-            BasicDBObject.parse("{" + "\"$project\": {" + "   \"topper\": 1" + " }" + "}"));
+            BasicDBObject.parse(
+                "{" + "\"$project\": {" + "   \"topper\": \"$topper\"" + " }" + "}"));
 
     testAggregation(query, pipeline);
   }
@@ -416,7 +417,7 @@ class MongoQueryExecutorTest {
                     + "     }"
                     + "   }"
                     + "}"),
-            BasicDBObject.parse("{" + "\"$project\": {" + "   \"total\": 1" + " }" + "}"));
+            BasicDBObject.parse("{" + "\"$project\": {" + "   \"total\": \"$total\"" + " }" + "}"));
 
     testAggregation(query, pipeline);
   }
@@ -458,7 +459,7 @@ class MongoQueryExecutorTest {
                     + "     }"
                     + "   }"
                     + "}"),
-            BasicDBObject.parse("{" + "\"$project\": {" + "   \"total\": 1" + " }" + "}"),
+            BasicDBObject.parse("{" + "\"$project\": {" + "   \"total\": \"$total\"" + " }" + "}"),
             BasicDBObject.parse(
                 "{"
                     + "\"$match\":"
@@ -504,7 +505,11 @@ class MongoQueryExecutorTest {
                     + "   }"
                     + "}"),
             BasicDBObject.parse(
-                "{" + "\"$project\": {" + "     \"averageHighScore\": 1" + " }" + "}"),
+                "{"
+                    + "\"$project\": {"
+                    + "     \"averageHighScore\": \"$averageHighScore\""
+                    + " }"
+                    + "}"),
             BasicDBObject.parse(
                 "{"
                     + "   \"$sort\": {"


### PR DESCRIPTION
## Description
* Encode alias in generated selections for aggregations
* Encode alias for AggregateExpression and FunctionExpression while projecting them

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
* Modified unit and integration tests to cover the scenario

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
