### PR TITLE
Calling hasNext on closed cursor is throwing error.

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.hypertrace.core.documentstore.utils.Utils.convertJsonToMap;
 import static org.hypertrace.core.documentstore.utils.Utils.createDocumentsFromResource;
 import static org.hypertrace.core.documentstore.utils.Utils.readFileFromResource;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -102,6 +103,16 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertSizeEqual(resultDocs, "mongo/collection_data.json");
+  }
+
+  @Test
+  public void testHasNext() throws IOException {
+    Query query = Query.builder().build();
+
+    Iterator<Document> resultDocs = collection.find(query);
+    assertSizeEqual(resultDocs, "mongo/collection_data.json");
+    // hasNext should not throw error even after cursor is closed
+    assertFalse(resultDocs.hasNext());
   }
 
   @Test

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -588,14 +588,19 @@ public class MongoCollection implements Collection {
 
   private CloseableIterator<Document> convertToDocumentIterator(MongoCursor<BasicDBObject> cursor) {
     return new CloseableIterator<>() {
+      private boolean closed = false;
+
       @Override
       public void close() {
-        cursor.close();
+        if (!closed) {
+          cursor.close();
+        }
+        closed = true;
       }
 
       @Override
       public boolean hasNext() {
-        boolean hasNext = cursor.hasNext();
+        boolean hasNext = !closed && cursor.hasNext();
         if (!hasNext) {
           close();
         }


### PR DESCRIPTION
Calling hasNext on closed cursor is throwing error. Need to maintain closed state locally.