### PR TITLE
Count query by filter

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -527,6 +527,17 @@ public class MongoQueryExecutorIntegrationTest {
     assertEquals(1, collection.count(filter));
   }
 
+  @Test
+  public void testCountNonMatching() {
+    final Filter filter =
+        Filter.builder()
+            .expression(
+                RelationalExpression.of(
+                    IdentifierExpression.of("props.brand"), EQ, ConstantExpression.of("Hamam")))
+            .build();
+    assertEquals(0, collection.count(filter));
+  }
+
   private static void assertDocsEqual(Iterator<Document> documents, String filePath)
       throws IOException {
     String fileContent = readFileFromResource(filePath).orElseThrow();

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -509,7 +509,21 @@ public class MongoQueryExecutorIntegrationTest {
 
   @Test
   public void testCountMatching() {
-    final Filter filter = Filter.builder().expression(LogicalExpression.builder().operator(AND).operand(RelationalExpression.of(IdentifierExpression.of("item"), EQ, ConstantExpression.of("Soap"))).operand(RelationalExpression.of(IdentifierExpression.of("props.brand"), EQ, ConstantExpression.of("Dettol"))).build()).build();
+    final Filter filter =
+        Filter.builder()
+            .expression(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("item"), EQ, ConstantExpression.of("Soap")))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("props.brand"),
+                            EQ,
+                            ConstantExpression.of("Dettol")))
+                    .build())
+            .build();
     assertEquals(1, collection.count(filter));
   }
 

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -524,7 +524,7 @@ public class MongoQueryExecutorIntegrationTest {
                             ConstantExpression.of("Dettol")))
                     .build())
             .build();
-    assertEquals(1, collection.count(filter));
+    assertEquals(1, collection.total(filter));
   }
 
   @Test
@@ -535,7 +535,7 @@ public class MongoQueryExecutorIntegrationTest {
                 RelationalExpression.of(
                     IdentifierExpression.of("props.brand"), EQ, ConstantExpression.of("Hamam")))
             .build();
-    assertEquals(0, collection.count(filter));
+    assertEquals(0, collection.total(filter));
   }
 
   private static void assertDocsEqual(Iterator<Document> documents, String filePath)

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.hypertrace.core.documentstore.utils.Utils.convertJsonToMap;
 import static org.hypertrace.core.documentstore.utils.Utils.createDocumentsFromResource;
 import static org.hypertrace.core.documentstore.utils.Utils.readFileFromResource;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.typesafe.config.Config;
@@ -52,7 +53,6 @@ import org.hypertrace.core.documentstore.query.SelectionSpec;
 import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -491,8 +491,8 @@ public class MongoQueryExecutorIntegrationTest {
 
   @Test
   public void testUnnestAndAggregate() throws IOException {
-    org.hypertrace.core.documentstore.query.Query query =
-        org.hypertrace.core.documentstore.query.Query.builder()
+    Query query =
+        Query.builder()
             .addSelection(IdentifierExpression.of("sales.medium.type"))
             .addAggregation(IdentifierExpression.of("sales.medium.type"))
             .addSelection(
@@ -507,6 +507,12 @@ public class MongoQueryExecutorIntegrationTest {
     assertDocsEqual(iterator, "mongo/aggregate_on_nested_array_reponse.json");
   }
 
+  @Test
+  public void testCountMatching() {
+    final Filter filter = Filter.builder().expression(LogicalExpression.builder().operator(AND).operand(RelationalExpression.of(IdentifierExpression.of("item"), EQ, ConstantExpression.of("Soap"))).operand(RelationalExpression.of(IdentifierExpression.of("props.brand"), EQ, ConstantExpression.of("Dettol"))).build()).build();
+    assertEquals(1, collection.count(filter));
+  }
+
   private static void assertDocsEqual(Iterator<Document> documents, String filePath)
       throws IOException {
     String fileContent = readFileFromResource(filePath).orElseThrow();
@@ -517,7 +523,7 @@ public class MongoQueryExecutorIntegrationTest {
       actual.add(convertDocumentToMap(documents.next()));
     }
 
-    Assertions.assertEquals(expected, actual);
+    assertEquals(expected, actual);
   }
 
   private static void assertSizeEqual(Iterator<Document> documents, String filePath)
@@ -530,6 +536,6 @@ public class MongoQueryExecutorIntegrationTest {
       documents.next();
     }
 
-    Assertions.assertEquals(expected, actual);
+    assertEquals(expected, actual);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -110,7 +110,7 @@ public interface Collection {
    * @return the number of documents matching the passed filter conditions Note that this method is
    *     a generic version of {@link #total(Query)}
    */
-  long count(final org.hypertrace.core.documentstore.query.Filter filter);
+  long total(final org.hypertrace.core.documentstore.query.Filter filter);
 
   /**
    * @return the total number of documents matching the query applying the filters passed, and

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -106,6 +106,11 @@ public interface Collection {
   /** @return the number of documents in the collection */
   long count();
 
+  /** @return the number of documents matching the passed filter conditions
+   * Note that this method is a generic version of {@link #count()}
+   */
+  long count(final org.hypertrace.core.documentstore.query.Filter filter);
+
   /**
    * @return the total number of documents matching the query applying the filters passed, and
    *     ignoring offset and limit

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -108,7 +108,7 @@ public interface Collection {
 
   /**
    * @return the number of documents matching the passed filter conditions Note that this method is
-   *     a generic version of {@link #count()}
+   *     a generic version of {@link #total(Query)}
    */
   long count(final org.hypertrace.core.documentstore.query.Filter filter);
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -106,8 +106,9 @@ public interface Collection {
   /** @return the number of documents in the collection */
   long count();
 
-  /** @return the number of documents matching the passed filter conditions
-   * Note that this method is a generic version of {@link #count()}
+  /**
+   * @return the number of documents matching the passed filter conditions Note that this method is
+   *     a generic version of {@link #count()}
    */
   long count(final org.hypertrace.core.documentstore.query.Filter filter);
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -506,7 +506,7 @@ public class MongoCollection implements Collection {
   }
 
   @Override
-  public long count(final org.hypertrace.core.documentstore.query.Filter filter) {
+  public long total(final org.hypertrace.core.documentstore.query.Filter filter) {
     return queryExecutor.count(filter);
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -506,6 +506,11 @@ public class MongoCollection implements Collection {
   }
 
   @Override
+  public long count(final org.hypertrace.core.documentstore.query.Filter filter) {
+    return queryExecutor.count(filter);
+  }
+
+  @Override
   public long total(Query query) {
     Map<String, Object> map = new HashMap<>();
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bson.conversions.Bson;
 import org.hypertrace.core.documentstore.mongo.parser.MongoFromTypeExpressionParser;
 import org.hypertrace.core.documentstore.mongo.query.transformer.MongoQueryTransformer;
+import org.hypertrace.core.documentstore.query.Filter;
 import org.hypertrace.core.documentstore.query.Pagination;
 import org.hypertrace.core.documentstore.query.Query;
 
@@ -77,6 +78,11 @@ public class MongoQueryExecutor {
     AggregateIterable<BasicDBObject> iterable = collection.aggregate(pipeline);
 
     return iterable.cursor();
+  }
+
+  public long count(final Filter filter) {
+    final BasicDBObject filterClause = getFilter(filter.getExpression());
+    return collection.countDocuments(filterClause);
   }
 
   private void logClauses(

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoFilterTypeExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoFilterTypeExpressionParser.java
@@ -40,8 +40,12 @@ public final class MongoFilterTypeExpressionParser implements FilterTypeExpressi
       return new BasicDBObject();
     }
 
-    FilterTypeExpressionVisitor parser = new MongoFilterTypeExpressionParser();
-    Map<String, Object> filter = filterOptional.get().accept(parser);
+    return getFilter(filterOptional.get());
+  }
+
+  public static BasicDBObject getFilter(final FilterTypeExpression filterTypeExpression) {
+    final FilterTypeExpressionVisitor parser = new MongoFilterTypeExpressionParser();
+    Map<String, Object> filter = filterTypeExpression.accept(parser);
     return new BasicDBObject(filter);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -397,7 +397,7 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public long count(org.hypertrace.core.documentstore.query.Filter filter) {
+  public long total(org.hypertrace.core.documentstore.query.Filter filter) {
     throw new UnsupportedOperationException();
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -397,6 +397,11 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
+  public long count(org.hypertrace.core.documentstore.query.Filter filter) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public long total(Query query) {
     StringBuilder totalSQLBuilder =
         new StringBuilder("SELECT COUNT(*) FROM ").append(collectionName);


### PR DESCRIPTION
## Description
Introduce counting documents based on the new filter DTO

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added necessary integration test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
