### PR TITLE
Make the Query DTO equatable/hashable

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/model/Hashable.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/model/Hashable.java
@@ -1,0 +1,9 @@
+package org.hypertrace.core.documentstore.expression.model;
+
+public interface Hashable {
+  @Override
+  int hashCode();
+
+  @Override
+  boolean equals(final Object object);
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/FilterTypeExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/FilterTypeExpression.java
@@ -1,11 +1,12 @@
 package org.hypertrace.core.documentstore.expression.type;
 
+import org.hypertrace.core.documentstore.expression.model.Hashable;
 import org.hypertrace.core.documentstore.parser.FilterTypeExpressionVisitor;
 
 /**
  * An interface to represent that the expression can be used in either the WHERE clause or the
  * HAVING clause of the query.
  */
-public interface FilterTypeExpression {
+public interface FilterTypeExpression extends Hashable {
   <T> T accept(final FilterTypeExpressionVisitor visitor);
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/FromTypeExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/FromTypeExpression.java
@@ -1,11 +1,12 @@
 package org.hypertrace.core.documentstore.expression.type;
 
+import org.hypertrace.core.documentstore.expression.model.Hashable;
 import org.hypertrace.core.documentstore.parser.FromTypeExpressionVisitor;
 
 /**
  * Expression to retrieve rows from the referenced tables Implementations can perform table
  * functions, join, lateral subqueries
  */
-public interface FromTypeExpression {
+public interface FromTypeExpression extends Hashable {
   <T> T accept(final FromTypeExpressionVisitor visitor);
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/GroupTypeExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/GroupTypeExpression.java
@@ -1,10 +1,11 @@
 package org.hypertrace.core.documentstore.expression.type;
 
+import org.hypertrace.core.documentstore.expression.model.Hashable;
 import org.hypertrace.core.documentstore.parser.GroupTypeExpressionVisitor;
 
 /**
  * An interface to represent that the expression can be used in the GROUP BY clause of the query.
  */
-public interface GroupTypeExpression {
+public interface GroupTypeExpression extends Hashable {
   <T> T accept(final GroupTypeExpressionVisitor visitor);
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/SelectTypeExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/SelectTypeExpression.java
@@ -1,8 +1,9 @@
 package org.hypertrace.core.documentstore.expression.type;
 
+import org.hypertrace.core.documentstore.expression.model.Hashable;
 import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
 
 /** An interface to represent that the expression can be used in the SELECT clause of the query. */
-public interface SelectTypeExpression {
+public interface SelectTypeExpression extends Hashable {
   <T> T accept(final SelectTypeExpressionVisitor visitor);
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/SortTypeExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/type/SortTypeExpression.java
@@ -1,10 +1,11 @@
 package org.hypertrace.core.documentstore.expression.type;
 
+import org.hypertrace.core.documentstore.expression.model.Hashable;
 import org.hypertrace.core.documentstore.parser.SortTypeExpressionVisitor;
 
 /**
  * An interface to represent that the expression can be used in the ORDER BY clause of the query.
  */
-public interface SortTypeExpression {
+public interface SortTypeExpression extends Hashable {
   <T> T accept(final SortTypeExpressionVisitor visitor);
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.Value;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hypertrace.core.documentstore.expression.operators.SortOrder;
 import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
@@ -67,15 +68,15 @@ import org.hypertrace.core.documentstore.expression.type.SortTypeExpression;
  *  </code>
  */
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
-@ToString
-public final class Query {
-  private final Selection selection; // Missing selection represents fetching all the columns
-  private final Filter filter;
-  private final Aggregation aggregation;
-  private final Filter aggregationFilter;
-  private final Sort sort;
-  private final Pagination pagination; // Missing pagination represents fetching all the records
-  private final FromClause fromClause;
+@Value
+public class Query {
+  Selection selection; // Missing selection represents fetching all the columns
+  Filter filter;
+  Aggregation aggregation;
+  Filter aggregationFilter;
+  Sort sort;
+  Pagination pagination; // Missing pagination represents fetching all the records
+  FromClause fromClause;
 
   public List<SelectionSpec> getSelections() {
     return selection == null ? emptyList() : unmodifiableList(selection.getSelectionSpecs());

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import lombok.Value;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hypertrace.core.documentstore.expression.operators.SortOrder;


### PR DESCRIPTION
## Description
Implement equals() and hashCode() in the Query DTO for equating them

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
