### PR TITLE
Implement aggregate count API for MongoCollection

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.hypertrace.core.documentstore.utils.Utils.convertDocumentToMap
 import static org.hypertrace.core.documentstore.utils.Utils.convertJsonToMap;
 import static org.hypertrace.core.documentstore.utils.Utils.createDocumentsFromResource;
 import static org.hypertrace.core.documentstore.utils.Utils.readFileFromResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -52,7 +53,6 @@ import org.hypertrace.core.documentstore.query.SelectionSpec;
 import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -103,6 +103,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertSizeEqual(resultDocs, "mongo/collection_data.json");
+    assertSizeEqual(query, "mongo/collection_data.json");
   }
 
   @Test
@@ -137,6 +138,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertDocsEqual(resultDocs, "mongo/simple_filter_response.json");
+    assertSizeEqual(query, "mongo/simple_filter_response.json");
   }
 
   @Test
@@ -163,6 +165,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertDocsEqual(resultDocs, "mongo/simple_filter_response.json");
+    assertSizeEqual(query, "mongo/simple_filter_response.json");
   }
 
   @Test
@@ -202,6 +205,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertDocsEqual(resultDocs, "mongo/filter_with_sorting_and_pagination_response.json");
+    assertSizeEqual(query, "mongo/filter_with_sorting_and_pagination_response.json");
   }
 
   @Test
@@ -243,6 +247,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertDocsEqual(resultDocs, "mongo/filter_with_sorting_and_pagination_response.json");
+    assertSizeEqual(query, "mongo/filter_with_sorting_and_pagination_response.json");
   }
 
   @Test
@@ -279,6 +284,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.find(query);
     assertDocsEqual(resultDocs, "mongo/filter_on_nested_fields_response.json");
+    assertSizeEqual(query, "mongo/filter_on_nested_fields_response.json");
   }
 
   @Test
@@ -287,6 +293,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertSizeEqual(resultDocs, "mongo/collection_data.json");
+    assertSizeEqual(query, "mongo/collection_data.json");
   }
 
   @Test
@@ -298,6 +305,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/count_response.json");
+    assertSizeEqual(query, "mongo/count_response.json");
   }
 
   @Test
@@ -310,6 +318,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/count_response.json");
+    assertSizeEqual(query, "mongo/count_response.json");
   }
 
   @Test
@@ -346,6 +355,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/sum_response.json");
+    assertSizeEqual(query, "mongo/sum_response.json");
   }
 
   @Test
@@ -385,6 +395,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/sum_response.json");
+    assertSizeEqual(query, "mongo/sum_response.json");
   }
 
   @Test
@@ -403,6 +414,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/aggregate_on_nested_fields_response.json");
+    assertSizeEqual(query, "mongo/aggregate_on_nested_fields_response.json");
   }
 
   @Test
@@ -417,6 +429,7 @@ public class MongoQueryExecutorIntegrationTest {
             .build();
 
     assertThrows(IllegalArgumentException.class, () -> collection.aggregate(query));
+    assertThrows(IllegalArgumentException.class, () -> collection.aggregateCount(query));
   }
 
   @Test
@@ -441,6 +454,7 @@ public class MongoQueryExecutorIntegrationTest {
             .build();
 
     assertThrows(UnsupportedOperationException.class, () -> collection.aggregate(query));
+    assertThrows(UnsupportedOperationException.class, () -> collection.aggregateCount(query));
   }
 
   @Test
@@ -467,6 +481,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/multi_level_grouping_response.json");
+    assertSizeEqual(query, "mongo/multi_level_grouping_response.json");
   }
 
   @Test
@@ -487,6 +502,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> resultDocs = collection.aggregate(query);
     assertDocsEqual(resultDocs, "mongo/distinct_count_response.json");
+    assertSizeEqual(query, "mongo/distinct_count_response.json");
   }
 
   @Test
@@ -506,6 +522,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsEqual(iterator, "mongo/aggregate_on_nested_array_reponse.json");
+    assertSizeEqual(query, "mongo/aggregate_on_nested_array_reponse.json");
   }
 
   @Test
@@ -520,6 +537,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsEqual(iterator, "mongo/unwind_preserving_empty_array_response.json");
+    assertSizeEqual(query, "mongo/unwind_preserving_empty_array_response.json");
   }
 
   @Test
@@ -534,6 +552,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsEqual(iterator, "mongo/unwind_not_preserving_empty_array_response.json");
+    assertSizeEqual(query, "mongo/unwind_not_preserving_empty_array_response.json");
   }
 
   @Test
@@ -553,6 +572,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsEqual(iterator, "mongo/unwind_response.json");
+    assertSizeEqual(query, "mongo/unwind_response.json");
   }
 
   @Test
@@ -581,6 +601,7 @@ public class MongoQueryExecutorIntegrationTest {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsEqual(iterator, "mongo/unwind_filter_response.json");
+    assertSizeEqual(query, "mongo/unwind_filter_response.json");
   }
 
   private static void assertDocsEqual(Iterator<Document> documents, String filePath)
@@ -593,7 +614,7 @@ public class MongoQueryExecutorIntegrationTest {
       actual.add(convertDocumentToMap(documents.next()));
     }
 
-    Assertions.assertEquals(expected, actual);
+    assertEquals(expected, actual);
   }
 
   private static void assertSizeEqual(Iterator<Document> documents, String filePath)
@@ -606,6 +627,13 @@ public class MongoQueryExecutorIntegrationTest {
       documents.next();
     }
 
-    Assertions.assertEquals(expected, actual);
+    assertEquals(expected, actual);
+  }
+
+  private static void assertSizeEqual(final Query query, final String filePath) throws IOException {
+    final long actualSize = collection.aggregateCount(query);
+    final String fileContent = readFileFromResource(filePath).orElseThrow();
+    final long expectedSize = convertJsonToMap(fileContent).size();
+    assertEquals(expectedSize, actualSize);
   }
 }

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -429,7 +429,7 @@ public class MongoQueryExecutorIntegrationTest {
             .build();
 
     assertThrows(IllegalArgumentException.class, () -> collection.aggregate(query));
-    assertThrows(IllegalArgumentException.class, () -> collection.aggregateCount(query));
+    assertThrows(IllegalArgumentException.class, () -> collection.count(query));
   }
 
   @Test
@@ -454,7 +454,7 @@ public class MongoQueryExecutorIntegrationTest {
             .build();
 
     assertThrows(UnsupportedOperationException.class, () -> collection.aggregate(query));
-    assertThrows(UnsupportedOperationException.class, () -> collection.aggregateCount(query));
+    assertThrows(UnsupportedOperationException.class, () -> collection.count(query));
   }
 
   @Test
@@ -631,7 +631,7 @@ public class MongoQueryExecutorIntegrationTest {
   }
 
   private static void assertSizeEqual(final Query query, final String filePath) throws IOException {
-    final long actualSize = collection.aggregateCount(query);
+    final long actualSize = collection.count(query);
     final String fileContent = readFileFromResource(filePath).orElseThrow();
     final long expectedSize = convertJsonToMap(fileContent).size();
     assertEquals(expectedSize, actualSize);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -81,15 +81,6 @@ public interface Collection {
   CloseableIterator<Document> aggregate(final org.hypertrace.core.documentstore.query.Query query);
 
   /**
-   * Count the result-set size of applying aggregations. Note that this method is a generic version
-   * of {@link #total(Query)}
-   *
-   * @param query The query definition whose result-set size is to be determined
-   * @return The number of documents conforming to the input query
-   */
-  long aggregateCount(final org.hypertrace.core.documentstore.query.Query query);
-
-  /**
    * Delete the document with the given key.
    *
    * @param key The {@link Key} of the document to be deleted.
@@ -128,6 +119,15 @@ public interface Collection {
    *     ignoring offset and limit
    */
   long total(Query query);
+
+  /**
+   * Count the result-set size of executing the given query. Note that this method is a generic
+   * version of {@link #count()} and {@link #total(Query)}
+   *
+   * @param query The query definition whose result-set size is to be determined
+   * @return The number of documents conforming to the input query
+   */
+  long count(final org.hypertrace.core.documentstore.query.Query query);
 
   /**
    * @param documents to be upserted in bulk

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Collection.java
@@ -81,6 +81,15 @@ public interface Collection {
   CloseableIterator<Document> aggregate(final org.hypertrace.core.documentstore.query.Query query);
 
   /**
+   * Count the result-set size of applying aggregations. Note that this method is a generic version
+   * of {@link #total(Query)}
+   *
+   * @param query The query definition whose result-set size is to be determined
+   * @return The number of documents conforming to the input query
+   */
+  long aggregateCount(final org.hypertrace.core.documentstore.query.Query query);
+
+  /**
    * Delete the document with the given key.
    *
    * @param key The {@link Key} of the document to be deleted.

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -475,7 +475,7 @@ public class MongoCollection implements Collection {
   }
 
   @Override
-  public long aggregateCount(org.hypertrace.core.documentstore.query.Query query) {
+  public long count(org.hypertrace.core.documentstore.query.Query query) {
     return queryExecutor.aggregationCount(query);
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -475,6 +475,11 @@ public class MongoCollection implements Collection {
   }
 
   @Override
+  public long aggregateCount(org.hypertrace.core.documentstore.query.Query query) {
+    return queryExecutor.aggregationCount(query);
+  }
+
+  @Override
   public boolean delete(Key key) {
     DeleteResult deleteResult = collection.deleteOne(this.selectionCriteriaForKey(key));
     return deleteResult.getDeletedCount() > 0;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -476,7 +476,7 @@ public class MongoCollection implements Collection {
 
   @Override
   public long count(org.hypertrace.core.documentstore.query.Query query) {
-    return queryExecutor.aggregationCount(query);
+    return queryExecutor.count(query);
   }
 
   @Override

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
@@ -83,7 +83,7 @@ public class MongoQueryExecutor {
     return iterable.cursor();
   }
 
-  public long aggregationCount(final Query originalQuery) {
+  public long count(final Query originalQuery) {
     final Query query = transformAndLog(originalQuery);
 
     final List<BasicDBObject> pipeline =

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutor.java
@@ -1,10 +1,13 @@
 package org.hypertrace.core.documentstore.mongo;
 
+import static java.lang.Long.parseLong;
 import static java.util.Collections.singleton;
 import static java.util.function.Predicate.not;
 import static org.hypertrace.core.documentstore.mongo.MongoPaginationHelper.applyPagination;
 import static org.hypertrace.core.documentstore.mongo.MongoPaginationHelper.getLimitClause;
 import static org.hypertrace.core.documentstore.mongo.MongoPaginationHelper.getSkipClause;
+import static org.hypertrace.core.documentstore.mongo.clause.MongoCountClauseSupplier.COUNT_ALIAS;
+import static org.hypertrace.core.documentstore.mongo.clause.MongoCountClauseSupplier.getCountClause;
 import static org.hypertrace.core.documentstore.mongo.parser.MongoFilterTypeExpressionParser.getFilter;
 import static org.hypertrace.core.documentstore.mongo.parser.MongoFilterTypeExpressionParser.getFilterClause;
 import static org.hypertrace.core.documentstore.mongo.parser.MongoGroupTypeExpressionParser.getGroupClause;
@@ -21,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.conversions.Bson;
@@ -77,6 +81,29 @@ public class MongoQueryExecutor {
     AggregateIterable<BasicDBObject> iterable = collection.aggregate(pipeline);
 
     return iterable.cursor();
+  }
+
+  public long aggregationCount(final Query originalQuery) {
+    final Query query = transformAndLog(originalQuery);
+
+    final List<BasicDBObject> pipeline =
+        Stream.concat(
+                AGGREGATE_PIPELINE_FUNCTIONS.stream()
+                    .flatMap(function -> function.apply(query).stream()),
+                Stream.of(getCountClause()))
+            .filter(not(BasicDBObject::isEmpty))
+            .collect(Collectors.toList());
+
+    logPipeline(pipeline);
+    final AggregateIterable<BasicDBObject> iterable = collection.aggregate(pipeline);
+
+    try (final MongoCursor<BasicDBObject> cursor = iterable.cursor()) {
+      if (cursor.hasNext()) {
+        return parseLong(cursor.next().get(COUNT_ALIAS).toString());
+      }
+    }
+
+    return 0;
   }
 
   private void logClauses(

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/clause/MongoCountClauseSupplier.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/clause/MongoCountClauseSupplier.java
@@ -1,0 +1,14 @@
+package org.hypertrace.core.documentstore.mongo.clause;
+
+import static org.hypertrace.core.documentstore.mongo.MongoUtils.PREFIX;
+
+import com.mongodb.BasicDBObject;
+
+public class MongoCountClauseSupplier {
+  public static final String COUNT_ALIAS = "count";
+  private static final String COUNT_CLAUSE = PREFIX + "count";
+
+  public static BasicDBObject getCountClause() {
+    return new BasicDBObject(COUNT_CLAUSE, COUNT_ALIAS);
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -291,7 +291,7 @@ public class PostgresCollection implements Collection {
   }
 
   @Override
-  public long aggregateCount(org.hypertrace.core.documentstore.query.Query query) {
+  public long count(org.hypertrace.core.documentstore.query.Query query) {
     throw new UnsupportedOperationException();
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -290,6 +290,11 @@ public class PostgresCollection implements Collection {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public long aggregateCount(org.hypertrace.core.documentstore.query.Query query) {
+    throw new UnsupportedOperationException();
+  }
+
   @VisibleForTesting
   protected PreparedStatement buildPreparedStatement(String sqlQuery, Params params)
       throws SQLException, RuntimeException {


### PR DESCRIPTION
## Description
Introduce an API to count aggregations

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
