### PR TITLE
Expose the document path to created time so that it can be used in filters in a generic way

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/Datastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/Datastore.java
@@ -17,4 +17,6 @@ public interface Datastore {
   Collection getCollection(String collectionName);
 
   boolean healthCheck();
+
+  String getCreatedTimePath();
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -56,14 +56,15 @@ import org.slf4j.LoggerFactory;
 
 /** An implementation of the {@link Collection} interface with MongoDB as the backend */
 public class MongoCollection implements Collection {
+  /* follow json/protobuf convention to make it deser, let's not make our life harder */
+  public static final String CREATED_TIME = "createdTime";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoCollection.class);
 
   // Fields automatically added for each document
   public static final String ID_KEY = "_id";
   private static final String LAST_UPDATE_TIME = "_lastUpdateTime";
   private static final String LAST_UPDATED_TIME = "lastUpdatedTime";
-  /* follow json/protobuf convention to make it deser, let's not make our life harder */
-  private static final String CREATED_TIME = "createdTime";
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoDatastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoDatastore.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore.mongo;
 
+import static org.hypertrace.core.documentstore.mongo.MongoCollection.CREATED_TIME;
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.FIELD_SEPARATOR;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -85,6 +86,11 @@ public class MongoDatastore implements Datastore {
   public boolean healthCheck() {
     Document document = this.database.runCommand(new Document("ping", "1"));
     return !document.isEmpty();
+  }
+
+  @Override
+  public String getCreatedTimePath() {
+    return CREATED_TIME;
   }
 
   @VisibleForTesting

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
@@ -132,6 +132,11 @@ public class PostgresDatastore implements Datastore {
     return false;
   }
 
+  @Override
+  public String getCreatedTimePath() {
+    return CREATED_AT;
+  }
+
   public Connection getPostgresClient() {
     return client;
   }


### PR DESCRIPTION
## Description
Expose the document path to created time so that it can be used in filters in a generic way

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
