### PR TITLE
feat: add support for selections of new query api

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -1588,7 +1588,7 @@ public class DocStoreTest {
                     IdentifierExpression.of("price"), EQ, ConstantExpression.of(10)))
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("props.brand"))
-     //       .addSelection(IdentifierExpression.of("props.seller.name"))
+            .addSelection(IdentifierExpression.of("props.seller.name"))
             .addSelection(
                 FunctionExpression.builder()
                     .operand(IdentifierExpression.of("price"))

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -1587,6 +1587,8 @@ public class DocStoreTest {
                 RelationalExpression.of(
                     IdentifierExpression.of("price"), EQ, ConstantExpression.of(10)))
             .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("props.brand"))
+     //       .addSelection(IdentifierExpression.of("props.seller.name"))
             .addSelection(
                 FunctionExpression.builder()
                     .operand(IdentifierExpression.of("price"))

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -1586,7 +1586,7 @@ public class DocStoreTest {
             .setFilter(
                 RelationalExpression.of(
                     IdentifierExpression.of("price"), EQ, ConstantExpression.of(10)))
-            .addSelection(IdentifierExpression.of("item"), "item")
+            .addSelection(IdentifierExpression.of("item"))
             .addSelection(
                 FunctionExpression.builder()
                     .operand(IdentifierExpression.of("price"))

--- a/document-store/src/integrationTest/resources/mongo/test_selection_expression_nested_fields_alias_result.json
+++ b/document-store/src/integrationTest/resources/mongo/test_selection_expression_nested_fields_alias_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "item": "Soap",
+    "total": 20,
+    "props_seller_name": "Metro Chemicals Pvt. Ltd.",
+    "props_brand": "Dettol"
+  },
+  {
+    "item": "Soap",
+    "total": 50
+  }
+]

--- a/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
+++ b/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
@@ -1,7 +1,10 @@
 [
   {
     "item": "Soap",
-    "total": 20
+    "total": 20,
+    "props": {
+      "brand": "Dettol"
+    }
   },
   {
     "item": "Soap",

--- a/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
+++ b/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
@@ -1,0 +1,10 @@
+[
+  {
+    "item": "Soap",
+    "total": 20
+  },
+  {
+    "item": "Soap",
+    "total": 50
+  }
+]

--- a/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
+++ b/document-store/src/integrationTest/resources/mongo/test_selection_expression_result.json
@@ -3,7 +3,10 @@
     "item": "Soap",
     "total": 20,
     "props": {
-      "brand": "Dettol"
+      "brand": "Dettol",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd."
+      }
     }
   },
   {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -1,6 +1,5 @@
 package org.hypertrace.core.documentstore.postgres;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
@@ -9,10 +8,12 @@ import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -281,11 +282,21 @@ public class PostgresCollection implements Collection {
   @Override
   public CloseableIterator<Document> find(
       final org.hypertrace.core.documentstore.query.Query query) {
-    throw new UnsupportedOperationException();
+    return executeQueryV1(query);
   }
 
   @Override
   public CloseableIterator<Document> aggregate(
+      final org.hypertrace.core.documentstore.query.Query query) {
+    return executeQueryV1(query);
+  }
+
+  @Override
+  public long count(org.hypertrace.core.documentstore.query.Query query) {
+    throw new UnsupportedOperationException();
+  }
+
+  private CloseableIterator<Document> executeQueryV1(
       final org.hypertrace.core.documentstore.query.Query query) {
     org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser queryParser =
         new org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser(collectionName);
@@ -294,16 +305,15 @@ public class PostgresCollection implements Collection {
       PreparedStatement preparedStatement =
           buildPreparedStatement(sqlQuery, queryParser.getParamsBuilder().build());
       ResultSet resultSet = preparedStatement.executeQuery();
-      return new PostgresResultIterator(resultSet);
+      CloseableIterator closeableIterator =
+          query.getSelections().size() > 0
+              ? new PostgresResultIteratorWithMetaData(preparedStatement.getMetaData(), resultSet)
+              : new PostgresResultIterator(resultSet);
+      return closeableIterator;
     } catch (SQLException e) {
       LOGGER.error("SQLException querying documents. query: {}", query, e);
     }
     return EMPTY_ITERATOR;
-  }
-
-  @Override
-  public long count(org.hypertrace.core.documentstore.query.Query query) {
-    throw new UnsupportedOperationException();
   }
 
   @VisibleForTesting
@@ -614,10 +624,10 @@ public class PostgresCollection implements Collection {
 
   static class PostgresResultIterator implements CloseableIterator {
 
-    private final ObjectMapper MAPPER = new ObjectMapper();
-    private ResultSet resultSet;
-    private boolean cursorMovedForward = false;
-    private boolean hasNext = false;
+    protected final ObjectMapper MAPPER = new ObjectMapper();
+    protected ResultSet resultSet;
+    protected boolean cursorMovedForward = false;
+    protected boolean hasNext = false;
 
     public PostgresResultIterator(ResultSet resultSet) {
       this.resultSet = resultSet;
@@ -651,7 +661,7 @@ public class PostgresCollection implements Collection {
       }
     }
 
-    private Document prepareDocument() throws SQLException, JsonProcessingException, IOException {
+    protected Document prepareDocument() throws SQLException, IOException {
       String documentString = resultSet.getString(DOCUMENT);
       ObjectNode jsonNode = (ObjectNode) MAPPER.readTree(documentString);
       jsonNode.remove(DOCUMENT_ID);
@@ -664,22 +674,31 @@ public class PostgresCollection implements Collection {
       return new JSONDocument(MAPPER.writeValueAsString(jsonNode));
     }
 
-    private String prepareNumericBlock(String fieldName, Object value) {
-      if (value instanceof Number) {
-        String fmt = "case jsonb_typeof(%s)\n" + "WHEN ‘number’ THEN (%s)::numeric > ?\n" + "end";
-      } else if (value instanceof Boolean) {
-        String fmtBoolean =
-            "case jsonb_typeof(<field>)\n"
-                + "WHEN 'boolean'  THEN (<field>)::boolean  > ?\n"
-                + "end";
-      }
-      return null;
-    }
-
     @SneakyThrows
     @Override
     public void close() {
       resultSet.close();
+    }
+  }
+
+  static class PostgresResultIteratorWithMetaData extends PostgresResultIterator {
+    protected ResultSetMetaData resultSetMetaData;
+
+    public PostgresResultIteratorWithMetaData(
+        ResultSetMetaData resultSetMetaData, ResultSet resultSet) {
+      super(resultSet);
+      this.resultSetMetaData = resultSetMetaData;
+    }
+
+    @Override
+    protected Document prepareDocument() throws SQLException, IOException {
+      int columnCount = resultSetMetaData.getColumnCount();
+      Map<String, Object> jsonNode = new HashMap();
+      for (int i = 1; i <= columnCount; i++) {
+        String columnName = resultSetMetaData.getColumnName(i);
+        jsonNode.put(columnName, MAPPER.readTree(resultSet.getString(i)));
+      }
+      return new JSONDocument(MAPPER.writeValueAsString(jsonNode));
     }
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
@@ -7,8 +7,10 @@ import org.hypertrace.core.documentstore.expression.type.GroupTypeExpression;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresFilterTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSelectTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.query.Pagination;
 import org.hypertrace.core.documentstore.query.Query;
+import org.hypertrace.core.documentstore.query.SelectionSpec;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 
 public class PostgresQueryParser {
@@ -30,6 +32,12 @@ public class PostgresQueryParser {
     StringBuilder sqlBuilder = new StringBuilder(String.format("SELECT * FROM %s", collection));
     paramsBuilder = Params.newBuilder();
 
+    // selection clause
+    Optional<String> selectionClause = parseSelection(query.getSelections());
+    if (selectionClause.isPresent()) {
+      sqlBuilder = new StringBuilder();
+      sqlBuilder.append(String.format("SELECT %s FROM %s", selectionClause.get(), collection));
+    }
     // where clause
     Optional<String> whereFilter = parseFilter(query.getFilter());
     if (whereFilter.isPresent()) {
@@ -61,6 +69,10 @@ public class PostgresQueryParser {
     }
 
     return sqlBuilder.toString();
+  }
+
+  private Optional<String> parseSelection(List<SelectionSpec> selectionSpecs) {
+    return Optional.ofNullable(PostgresSelectTypeExpressionVisitor.getSelections(selectionSpecs));
   }
 
   private Optional<String> parseFilter(Optional<FilterTypeExpression> filterTypeExpression) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresConstantExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresConstantExpressionVisitor.java
@@ -1,8 +1,14 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 
+import lombok.NoArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 
+@NoArgsConstructor
 public class PostgresConstantExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
+
+  public PostgresConstantExpressionVisitor(PostgresSelectTypeExpressionVisitor baseVisitor) {
+    super(baseVisitor);
+  }
 
   @Override
   public Object visit(final ConstantExpression expression) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
@@ -1,0 +1,43 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
+
+import lombok.NoArgsConstructor;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
+
+@NoArgsConstructor
+public class PostgresDataAccessorIdentifierExpressionVisitor
+    extends PostgresSelectTypeExpressionVisitor {
+
+  enum Type {
+    BOOL,
+    NUMERIC
+  }
+
+  private Type type = Type.NUMERIC;
+
+  public PostgresDataAccessorIdentifierExpressionVisitor(Type type) {
+    this.type = type;
+  }
+
+  public PostgresDataAccessorIdentifierExpressionVisitor(
+      PostgresSelectTypeExpressionVisitor baseVisitor) {
+    super(baseVisitor);
+  }
+
+  public PostgresDataAccessorIdentifierExpressionVisitor(
+      PostgresSelectTypeExpressionVisitor baseVisitor, Type type) {
+    super(baseVisitor);
+    this.type = type;
+  }
+
+  @Override
+  public String visit(final IdentifierExpression expression) {
+    String dataAccessor = PostgresUtils.prepareFieldDataAccessorExpr(expression.getName());
+    if (type.equals(Type.NUMERIC)) {
+      return PostgresUtils.prepareCast(dataAccessor, 1);
+    } else if (type.equals(Type.BOOL)) {
+      return PostgresUtils.prepareCast(dataAccessor, true);
+    }
+    return PostgresUtils.prepareCast(dataAccessor, "");
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
@@ -3,15 +3,11 @@ package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 import lombok.NoArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils.Type;
 
 @NoArgsConstructor
 public class PostgresDataAccessorIdentifierExpressionVisitor
     extends PostgresSelectTypeExpressionVisitor {
-
-  enum Type {
-    BOOL,
-    NUMERIC
-  }
 
   private Type type = Type.NUMERIC;
 
@@ -35,7 +31,7 @@ public class PostgresDataAccessorIdentifierExpressionVisitor
     String dataAccessor = PostgresUtils.prepareFieldDataAccessorExpr(expression.getName());
     if (type.equals(Type.NUMERIC)) {
       return PostgresUtils.prepareCast(dataAccessor, 1);
-    } else if (type.equals(Type.BOOL)) {
+    } else if (type.equals(Type.BOOLEAN)) {
       return PostgresUtils.prepareCast(dataAccessor, true);
     }
     return PostgresUtils.prepareCast(dataAccessor, "");

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDefaultSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDefaultSelectTypeExpressionVisitor.java
@@ -1,0 +1,35 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
+import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
+import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostgresDefaultSelectTypeExpressionVisitor
+    extends PostgresSelectTypeExpressionVisitor {
+  static final PostgresDefaultSelectTypeExpressionVisitor INSTANCE =
+      new PostgresDefaultSelectTypeExpressionVisitor();
+
+  @Override
+  public <T> T visit(final AggregateExpression expression) {
+    throw new UnsupportedOperationException(String.valueOf(expression));
+  }
+
+  @Override
+  public <T> T visit(final ConstantExpression expression) {
+    throw new UnsupportedOperationException(String.valueOf(expression));
+  }
+
+  @Override
+  public <T> T visit(final FunctionExpression expression) {
+    throw new UnsupportedOperationException(String.valueOf(expression));
+  }
+
+  @Override
+  public <T> T visit(final IdentifierExpression expression) {
+    throw new UnsupportedOperationException(String.valueOf(expression));
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFieldIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFieldIdentifierExpressionVisitor.java
@@ -1,0 +1,18 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
+
+import lombok.NoArgsConstructor;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
+
+@NoArgsConstructor
+public class PostgresFieldIdentifierExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
+
+  public PostgresFieldIdentifierExpressionVisitor(PostgresSelectTypeExpressionVisitor baseVisitor) {
+    super(baseVisitor);
+  }
+
+  @Override
+  public String visit(final IdentifierExpression expression) {
+    return PostgresUtils.prepareFieldAccessorExpr(expression.getName()).toString();
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 
+import java.util.Objects;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -30,8 +31,9 @@ public class PostgresFunctionExpressionVisitor extends PostgresSelectTypeExpress
     String childList =
         expression.getOperands().stream()
             .map(exp -> exp.accept(selectTypeExpressionVisitor))
-            .filter(str -> !StringUtils.isEmpty((String) str))
-            .map(str -> "" + str + "")
+            .filter(Objects::nonNull)
+            .map(Object::toString)
+            .filter(StringUtils::isNotEmpty)
             .collect(collector);
 
     return !childList.isEmpty() ? childList : null;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
@@ -1,0 +1,53 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
+
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
+import org.hypertrace.core.documentstore.expression.operators.FunctionOperator;
+import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
+
+public class PostgresFunctionExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
+  @Override
+  public String visit(final FunctionExpression expression) {
+    int numArgs = expression.getOperands().size();
+    if (numArgs == 0) {
+      throw new IllegalArgumentException(
+          String.format("%s should have at least one operand", expression));
+    }
+
+    SelectTypeExpressionVisitor selectTypeExpressionVisitor =
+        new PostgresIdentifierExpressionVisitor(new PostgresConstantExpressionVisitor());
+
+    if (numArgs == 1) {
+      String value = expression.getOperands().get(0).accept(selectTypeExpressionVisitor);
+      return String.format("%s( %s )", expression.getOperator().toString(), value);
+    }
+
+    Collector<String, ?, String> collector =
+        getCollectorForFunctionOperator(expression.getOperator());
+
+    String childList =
+        expression.getOperands().stream()
+            .map(exp -> exp.accept(selectTypeExpressionVisitor))
+            .filter(str -> !StringUtils.isEmpty((String) str))
+            .map(str -> "(" + str + ")")
+            .collect(collector);
+
+    return !childList.isEmpty() ? childList : null;
+  }
+
+  private Collector getCollectorForFunctionOperator(FunctionOperator operator) {
+    if (operator.equals(FunctionOperator.ADD)) {
+      return Collectors.joining(" + ");
+    } else if (operator.equals(FunctionOperator.SUBTRACT)) {
+      return Collectors.joining(" - ");
+    } else if (operator.equals(FunctionOperator.MULTIPLY)) {
+      return Collectors.joining(" * ");
+    } else if (operator.equals(FunctionOperator.DIVIDE)) {
+      return Collectors.joining(" / ");
+    }
+    throw new UnsupportedOperationException(
+        String.format("Query operation:%s not supported", operator));
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFunctionExpressionVisitor.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.operators.FunctionOperator;
-import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
 
 public class PostgresFunctionExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
   @Override
@@ -16,8 +15,9 @@ public class PostgresFunctionExpressionVisitor extends PostgresSelectTypeExpress
           String.format("%s should have at least one operand", expression));
     }
 
-    SelectTypeExpressionVisitor selectTypeExpressionVisitor =
-        new PostgresIdentifierExpressionVisitor(new PostgresConstantExpressionVisitor());
+    PostgresSelectTypeExpressionVisitor selectTypeExpressionVisitor =
+        new PostgresDataAccessorIdentifierExpressionVisitor(
+            new PostgresConstantExpressionVisitor());
 
     if (numArgs == 1) {
       String value = expression.getOperands().get(0).accept(selectTypeExpressionVisitor);
@@ -31,7 +31,7 @@ public class PostgresFunctionExpressionVisitor extends PostgresSelectTypeExpress
         expression.getOperands().stream()
             .map(exp -> exp.accept(selectTypeExpressionVisitor))
             .filter(str -> !StringUtils.isEmpty((String) str))
-            .map(str -> "(" + str + ")")
+            .map(str -> "" + str + "")
             .collect(collector);
 
     return !childList.isEmpty() ? childList : null;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresIdentifierExpressionVisitor.java
@@ -1,11 +1,23 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 
+@NoArgsConstructor
 public class PostgresIdentifierExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
+
+  @Setter private boolean isFieldAccessor = false;
+
+  public PostgresIdentifierExpressionVisitor(PostgresSelectTypeExpressionVisitor baseVisitor) {
+    super(baseVisitor);
+  }
 
   @Override
   public String visit(final IdentifierExpression expression) {
-    return expression.getName();
+    return isFieldAccessor
+        ? PostgresUtils.prepareFieldAccessorExpr(expression.getName()).toString()
+        : expression.getName();
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresIdentifierExpressionVisitor.java
@@ -1,14 +1,10 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 
 @NoArgsConstructor
 public class PostgresIdentifierExpressionVisitor extends PostgresSelectTypeExpressionVisitor {
-
-  @Setter private boolean isFieldAccessor = false;
 
   public PostgresIdentifierExpressionVisitor(PostgresSelectTypeExpressionVisitor baseVisitor) {
     super(baseVisitor);
@@ -16,8 +12,6 @@ public class PostgresIdentifierExpressionVisitor extends PostgresSelectTypeExpre
 
   @Override
   public String visit(final IdentifierExpression expression) {
-    return isFieldAccessor
-        ? PostgresUtils.prepareFieldAccessorExpr(expression.getName()).toString()
-        : expression.getName();
+    return expression.getName();
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
@@ -75,6 +75,7 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
       PostgresIdentifierExpressionVisitor identifierExpressionVisitor) {
     return !StringUtils.isEmpty(selectionSpec.getAlias())
         ? selectionSpec.getAlias()
-        : selectionSpec.getExpression().accept(identifierExpressionVisitor);
+        : StringUtils.replace(
+            selectionSpec.getExpression().accept(identifierExpressionVisitor), ".", "_dot_");
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
@@ -1,30 +1,69 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
 import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.query.SelectionSpec;
 
 public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeExpressionVisitor {
 
+  protected final PostgresSelectTypeExpressionVisitor baseVisitor;
+
+  protected PostgresSelectTypeExpressionVisitor() {
+    this(PostgresDefaultSelectTypeExpressionVisitor.INSTANCE);
+  }
+
+  protected PostgresSelectTypeExpressionVisitor(
+      final PostgresSelectTypeExpressionVisitor baseVisitor) {
+    this.baseVisitor = baseVisitor;
+  }
+
   @Override
   public <T> T visit(final AggregateExpression expression) {
-    throw new UnsupportedOperationException(String.valueOf(expression));
+    return baseVisitor.visit(expression);
   }
 
   @Override
   public <T> T visit(final ConstantExpression expression) {
-    throw new UnsupportedOperationException(String.valueOf(expression));
+    return baseVisitor.visit(expression);
   }
 
   @Override
   public <T> T visit(final FunctionExpression expression) {
-    throw new UnsupportedOperationException(String.valueOf(expression));
+    return baseVisitor.visit(expression);
   }
 
   @Override
   public <T> T visit(final IdentifierExpression expression) {
-    throw new UnsupportedOperationException(String.valueOf(expression));
+    return baseVisitor.visit(expression);
+  }
+
+  public static String getSelections(final List<SelectionSpec> selectionSpecs) {
+    PostgresIdentifierExpressionVisitor selectTypeExpressionVisitor =
+        new PostgresIdentifierExpressionVisitor(new PostgresFunctionExpressionVisitor());
+    selectTypeExpressionVisitor.setFieldAccessor(true);
+
+    String childList =
+        selectionSpecs.stream()
+            .map(
+                selectionSpec ->
+                    Pair.of(
+                        selectionSpec.getExpression().accept(selectTypeExpressionVisitor),
+                        selectionSpec.getAlias()))
+            .filter(p -> !StringUtils.isEmpty((String) p.getLeft()))
+            .map(
+                p ->
+                    StringUtils.isNotEmpty(p.getRight())
+                        ? "" + p.getLeft() + " AS " + p.getRight()
+                        : "" + p.getLeft() + "")
+            .collect(Collectors.joining(", "));
+
+    return !childList.isEmpty() ? childList : null;
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
@@ -45,9 +45,10 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
   }
 
   public static String getSelections(final List<SelectionSpec> selectionSpecs) {
-    PostgresIdentifierExpressionVisitor selectTypeExpressionVisitor =
-        new PostgresIdentifierExpressionVisitor(new PostgresFunctionExpressionVisitor());
-    selectTypeExpressionVisitor.setFieldAccessor(true);
+    // TODO: As in the current impl, the item without alias will have column name as ?column?
+    // need to take care of it, but what should be the name of nested field?
+    PostgresSelectTypeExpressionVisitor selectTypeExpressionVisitor =
+        new PostgresFieldIdentifierExpressionVisitor(new PostgresFunctionExpressionVisitor());
 
     String childList =
         selectionSpecs.stream()

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
@@ -58,7 +58,7 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
                 selectionSpec ->
                     Pair.of(
                         selectionSpec.getExpression().accept(selectTypeExpressionVisitor),
-                        selectionSpec.getAlias()))
+                        getAlias(selectionSpec, identifierExpressionVisitor)))
             .filter(p -> !StringUtils.isEmpty((String) p.getLeft()))
             .map(
                 p ->
@@ -70,7 +70,7 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
     return !childList.isEmpty() ? childList : null;
   }
 
-  private String getAlias(
+  private static String getAlias(
       SelectionSpec selectionSpec,
       PostgresIdentifierExpressionVisitor identifierExpressionVisitor) {
     return !StringUtils.isEmpty(selectionSpec.getAlias())

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresSelectTypeExpressionVisitor.java
@@ -45,10 +45,12 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
   }
 
   public static String getSelections(final List<SelectionSpec> selectionSpecs) {
-    // TODO: As in the current impl, the item without alias will have column name as ?column?
-    // need to take care of it, but what should be the name of nested field?
     PostgresSelectTypeExpressionVisitor selectTypeExpressionVisitor =
         new PostgresFieldIdentifierExpressionVisitor(new PostgresFunctionExpressionVisitor());
+
+    // used for if alias is missing
+    PostgresIdentifierExpressionVisitor identifierExpressionVisitor =
+        new PostgresIdentifierExpressionVisitor();
 
     String childList =
         selectionSpecs.stream()
@@ -66,5 +68,13 @@ public abstract class PostgresSelectTypeExpressionVisitor implements SelectTypeE
             .collect(Collectors.joining(", "));
 
     return !childList.isEmpty() ? childList : null;
+  }
+
+  private String getAlias(
+      SelectionSpec selectionSpec,
+      PostgresIdentifierExpressionVisitor identifierExpressionVisitor) {
+    return !StringUtils.isEmpty(selectionSpec.getAlias())
+        ? selectionSpec.getAlias()
+        : selectionSpec.getExpression().accept(identifierExpressionVisitor);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -7,9 +7,11 @@ import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOC_
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.ID;
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.UPDATED_AT;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
 
@@ -17,6 +19,8 @@ public class PostgresUtils {
   private static final String QUESTION_MARK = "?";
   private static final String JSON_FIELD_ACCESSOR = "->";
   private static final String JSON_DATA_ACCESSOR = "->>";
+  private static final String DOT_STR = "_dot_";
+  private static final String DOT = ".";
 
   private static final Set<String> OUTER_COLUMNS = Set.of(CREATED_AT, ID, UPDATED_AT);
 
@@ -209,5 +213,21 @@ public class PostgresUtils {
     }
     String filters = filterString.toString();
     return filters;
+  }
+
+  public static List<String> splitNestedField(String nestedFieldName) {
+    return Arrays.asList(StringUtils.split(nestedFieldName, DOT));
+  }
+
+  public static boolean isEncodedNestedField(String fieldName) {
+    return fieldName.contains(DOT_STR) ? true : false;
+  }
+
+  public static String encodeAliasForNestedField(String nestedFieldName) {
+    return StringUtils.replace(nestedFieldName, DOT, DOT_STR);
+  }
+
+  public static String decodeAliasForNestedField(String nestedFieldName) {
+    return StringUtils.replace(nestedFieldName, DOT_STR, DOT);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -56,7 +56,7 @@ public class PostgresUtils {
     return fieldPrefix.toString();
   }
 
-  private static String prepareCast(String field, Object value) {
+  public static String prepareCast(String field, Object value) {
     String fmt = "CAST (%s AS %s)";
 
     // handle the case if the value type is collection for filter operator - `IN`

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -20,7 +20,7 @@ public class PostgresUtils {
 
   private static final Set<String> OUTER_COLUMNS = Set.of(CREATED_AT, ID, UPDATED_AT);
 
-  private static StringBuilder prepareFieldAccessorExpr(String fieldName) {
+  public static StringBuilder prepareFieldAccessorExpr(String fieldName) {
     // Generate json field accessor statement
     if (!OUTER_COLUMNS.contains(fieldName)) {
       StringBuilder filterString = new StringBuilder(DOCUMENT);
@@ -39,7 +39,7 @@ public class PostgresUtils {
    * keys. Note: It doesn't handle array elements in json document. e.g SELECT * FROM TABLE where
    * document ->> 'first' = 'name' and document -> 'address' ->> 'pin' = "00000"
    */
-  private static String prepareFieldDataAccessorExpr(String fieldName) {
+  public static String prepareFieldDataAccessorExpr(String fieldName) {
     StringBuilder fieldPrefix = new StringBuilder(fieldName);
     if (!OUTER_COLUMNS.contains(fieldName)) {
       fieldPrefix = new StringBuilder(DOCUMENT);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -131,4 +131,19 @@ public class PostgresQueryParserTest {
     Assertions.assertEquals(5, params.getObjectParams().get(2));
     Assertions.assertEquals(10, params.getObjectParams().get(3));
   }
+
+  @Test
+  void testBasicSelectionExpression() {
+    Query query =
+        Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("price"))
+            .build();
+    PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION);
+    String sql = postgresQueryParser.parse(query);
+    Assertions.assertEquals("SELECT document->'item', document->'price' FROM testCollection", sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    Assertions.assertEquals(0, params.getObjectParams().size());
+  }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -143,7 +143,8 @@ public class PostgresQueryParserTest {
             .build();
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION);
     String sql = postgresQueryParser.parse(query);
-    Assertions.assertEquals("SELECT document->'item', document->'price' FROM testCollection", sql);
+    Assertions.assertEquals(
+        "SELECT document->'item' AS item, document->'price' AS price FROM testCollection", sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
     Assertions.assertEquals(0, params.getObjectParams().size());
@@ -165,7 +166,7 @@ public class PostgresQueryParserTest {
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION);
     String sql = postgresQueryParser.parse(query);
     Assertions.assertEquals(
-        "SELECT document->'item', CAST (document->>'price' AS NUMERIC) "
+        "SELECT document->'item' AS item, CAST (document->>'price' AS NUMERIC) "
             + "* CAST (document->>'quantity' AS NUMERIC) AS total FROM testCollection",
         sql);
 


### PR DESCRIPTION
As part of the supporting ticket: https://github.com/hypertrace/document-store/issues/82,  

This is the `third` PR in the series. It takes care of 
- supporting selections (older API always used to return full document)
- adds support for FunctionalType expression
- adds the similar pattern of composing SelectionTypeExpression visitors
- adds different types of Identifier visitor for data accessor, field accessor of JSONB document
- adds basic unit tests for selection
- adds integration test both for `mongo` + `Postgres` for a query involving selection
- handles nested fields scenarios

Note:
There is difference between below two queries:
Q1. `SELECT document->'item' AS item, document->'price' AS price FROM testCollection`
Q2. `SELECT document->'item', document->'price' AS price FROM testCollection`

If, we don't provide an alias name as exp Q1, the name of the return column for jsonb type will be `?column?`. So, as part of the impl, we are defaulting to the field name as an alias if user-defined alias is not provided.
