### PR TITLE
feat: add supports for aggregation filter expression for new query api

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
@@ -1,8 +1,10 @@
 package org.hypertrace.core.documentstore.postgres.query.v1;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
+import lombok.Getter;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresFilterTypeExpressionVisitor;
@@ -10,95 +12,101 @@ import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresGroup
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSelectTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.query.Pagination;
 import org.hypertrace.core.documentstore.query.Query;
-import org.hypertrace.core.documentstore.query.SelectionSpec;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 
 public class PostgresQueryParser {
   private static String NOT_YET_SUPPORTED = "Not yet supported %s";
-  private Builder paramsBuilder;
   private final String collection;
+
+  @Getter private Builder paramsBuilder;
+
+  @Getter private Query query;
+
+  @Getter private Map<String, String> pgSelections; // alias to field name
+
+  private void resetParser(Query query) {
+    this.query = query;
+    paramsBuilder = Params.newBuilder();
+    pgSelections = new HashMap<>();
+  }
 
   public PostgresQueryParser(String collection) {
     this.collection = collection;
   }
 
-  public Builder getParamsBuilder() {
-    return paramsBuilder;
-  }
-
   public String parse(Query query) {
     // prepare selection and form clause
     // TODO : add impl for selection + form clause for unwind
-    StringBuilder sqlBuilder = new StringBuilder(String.format("SELECT * FROM %s", collection));
-    paramsBuilder = Params.newBuilder();
+    StringBuilder sqlBuilder = new StringBuilder();
+    this.resetParser(query);
 
-    // selection clause
-    Optional<String> selectionClause = parseSelection(query.getSelections());
-    if (selectionClause.isPresent()) {
-      sqlBuilder = new StringBuilder();
-      sqlBuilder.append(String.format("SELECT %s FROM %s", selectionClause.get(), collection));
-    }
     // where clause
-    Optional<String> whereFilter = parseFilter(query.getFilter());
+    Optional<String> whereFilter = parseFilter();
     if (whereFilter.isPresent()) {
       sqlBuilder.append(String.format(" WHERE %s", whereFilter.get()));
     }
 
+    // selection clause
+    Optional<String> selectionClause = parseSelection();
+    if (selectionClause.isPresent()) {
+      sqlBuilder.insert(0, String.format("SELECT %s FROM %s", selectionClause.get(), collection));
+    } else {
+      sqlBuilder.insert(0, String.format("SELECT * FROM %s", collection));
+    }
+
     // group by
-    Optional<String> groupBy = parseGroupBy(query);
+    Optional<String> groupBy = parseGroupBy();
     if (groupBy.isPresent()) {
       sqlBuilder.append(String.format(" GROUP BY %s", groupBy.get()));
     }
 
     // having
-    Optional<String> having = parseHaving(query.getAggregationFilter());
+    Optional<String> having = parseHaving();
     if (having.isPresent()) {
       sqlBuilder.append(String.format(" HAVING %s", having.get()));
     }
 
     // order by
-    Optional<String> orderBy = parseOrderBy(query.getSorts());
-    if (having.isPresent()) {
+    Optional<String> orderBy = parseOrderBy();
+    if (orderBy.isPresent()) {
       sqlBuilder.append(String.format(" ORDER BY %s", orderBy.get()));
     }
 
     // offset and limit
-    Optional<String> pagination = parsePagination(query.getPagination());
-    if (having.isPresent()) {
+    Optional<String> pagination = parsePagination();
+    if (pagination.isPresent()) {
       sqlBuilder.append(String.format(" %s", pagination.get()));
     }
 
     return sqlBuilder.toString();
   }
 
-  private Optional<String> parseSelection(List<SelectionSpec> selectionSpecs) {
-    return Optional.ofNullable(PostgresSelectTypeExpressionVisitor.getSelections(selectionSpecs));
+  private Optional<String> parseSelection() {
+    return Optional.ofNullable(PostgresSelectTypeExpressionVisitor.getSelections(this));
   }
 
-  private Optional<String> parseFilter(Optional<FilterTypeExpression> filterTypeExpression) {
-    return filterTypeExpression.map(
-        expression -> expression.accept(new PostgresFilterTypeExpressionVisitor(this)));
+  private Optional<String> parseFilter() {
+    return PostgresFilterTypeExpressionVisitor.getFilterClause(this);
   }
 
-  private Optional<String> parseGroupBy(Query query) {
-    return Optional.ofNullable(PostgresGroupTypeExpressionVisitor.getGroupByClause(query));
+  private Optional<String> parseGroupBy() {
+    return Optional.ofNullable(PostgresGroupTypeExpressionVisitor.getGroupByClause(this));
   }
 
-  private Optional<String> parseHaving(Optional<FilterTypeExpression> filterTypeExpression) {
-    if (filterTypeExpression.isPresent()) {
-      throw new UnsupportedOperationException(String.format(NOT_YET_SUPPORTED, "having clause"));
-    }
-    return Optional.empty();
+  private Optional<String> parseHaving() {
+    return PostgresFilterTypeExpressionVisitor.getAggregationFilterClause(this);
   }
 
-  private Optional<String> parseOrderBy(List<SortingSpec> sortingSpecs) {
+  private Optional<String> parseOrderBy() {
+    List<SortingSpec> sortingSpecs = this.query.getSorts();
     if (sortingSpecs.size() > 0) {
       throw new UnsupportedOperationException(String.format(NOT_YET_SUPPORTED, "order by clause"));
     }
     return Optional.empty();
   }
 
-  private Optional<String> parsePagination(Optional<Pagination> pagination) {
+  private Optional<String> parsePagination() {
+    Optional<Pagination> pagination = this.query.getPagination();
     if (pagination.isPresent()) {
       throw new UnsupportedOperationException(
           String.format(NOT_YET_SUPPORTED, "pagination clause"));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresGroupTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresGroupTypeExpressionVisitor.java
@@ -10,6 +10,7 @@ import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.operators.AggregationOperator;
 import org.hypertrace.core.documentstore.expression.type.GroupTypeExpression;
 import org.hypertrace.core.documentstore.parser.GroupTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser;
 import org.hypertrace.core.documentstore.query.Query;
 
 public class PostgresGroupTypeExpressionVisitor implements GroupTypeExpressionVisitor {
@@ -28,7 +29,8 @@ public class PostgresGroupTypeExpressionVisitor implements GroupTypeExpressionVi
     return selectTypeExpressionVisitor.visit(expression);
   }
 
-  public static String getGroupByClause(final Query query) {
+  public static String getGroupByClause(PostgresQueryParser postgresQueryParser) {
+    Query query = postgresQueryParser.getQuery();
     if (query.getAggregations().size() <= 0) return null;
 
     if (!validate(query)) {


### PR DESCRIPTION
As part of the supporting ticket: https://github.com/hypertrace/document-store/issues/82,  

This is the `fifth` PR in the series. It takes care of 
- supporting aggregation filter
- refactor a code to take PostgresQueryParser as the running object
- adds support for memorizing alias expressions in PostgresQueryParser
- adds unit test for having clause
- adds integration test for having clause

Note:
We can't use the alias in WHERE / HAVING clause in SQL expression. So, to support it, we need to rewrite the alias expression.

As an example, below is not a valid query:
```
SELECT COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) AS qty_count, document->'item' AS item 
FROM testCollection 
GROUP BY document->'item' 
HAVING qty_count <= 10
```

However, we can re-write it as:
```
SELECT COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) AS qty_count, document->'item' AS item 
FROM testCollection 
GROUP BY document->'item' 
HAVING COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) <= 10
```
