### PR TITLE
feat: add supports for pagination expression for new api

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorIntegrationTest.java
@@ -170,46 +170,6 @@ public class MongoQueryExecutorIntegrationTest {
   }
 
   @Test
-  public void testFindWithSortingAndPagination() throws IOException {
-    List<SelectionSpec> selectionSpecs =
-        List.of(
-            SelectionSpec.of(IdentifierExpression.of("item")),
-            SelectionSpec.of(IdentifierExpression.of("price")),
-            SelectionSpec.of(IdentifierExpression.of("quantity")),
-            SelectionSpec.of(IdentifierExpression.of("date")));
-    Selection selection = Selection.builder().selectionSpecs(selectionSpecs).build();
-
-    Filter filter =
-        Filter.builder()
-            .expression(
-                RelationalExpression.of(
-                    IdentifierExpression.of("item"),
-                    IN,
-                    ConstantExpression.ofStrings(List.of("Mirror", "Comb", "Shampoo", "Bottle"))))
-            .build();
-
-    Sort sort =
-        Sort.builder()
-            .sortingSpec(SortingSpec.of(IdentifierExpression.of("quantity"), DESC))
-            .sortingSpec(SortingSpec.of(IdentifierExpression.of("item"), ASC))
-            .build();
-
-    Pagination pagination = Pagination.builder().offset(1).limit(3).build();
-
-    Query query =
-        Query.builder()
-            .setSelection(selection)
-            .setFilter(filter)
-            .setSort(sort)
-            .setPagination(pagination)
-            .build();
-
-    Iterator<Document> resultDocs = collection.find(query);
-    assertDocsEqual(resultDocs, "mongo/filter_with_sorting_and_pagination_response.json");
-    assertSizeEqual(query, "mongo/filter_with_sorting_and_pagination_response.json");
-  }
-
-  @Test
   public void testFindWithDuplicateSortingAndPagination() throws IOException {
     List<SelectionSpec> selectionSpecs =
         List.of(

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
@@ -112,4 +112,23 @@ public class Utils {
     assertEquals(expected, actual);
     assertEquals(expectedSize, actualSize);
   }
+
+  public static void assertDocsAndSizeEqualWithoutOrder(
+      Iterator<Document> documents, String filePath, int expectedSize) throws IOException {
+    String fileContent = readFileFromResource(filePath).orElseThrow();
+    List<Map<String, Object>> expectedDocs = convertJsonToMap(fileContent);
+
+    List<Map<String, Object>> actualDocs = new ArrayList<>();
+    int actualSize = 0;
+    while (documents.hasNext()) {
+      Map<String, Object> doc = convertDocumentToMap(documents.next());
+      actualDocs.add(doc);
+      actualSize++;
+    }
+
+    long count =
+        expectedDocs.stream().filter(expectedDoc -> actualDocs.contains(expectedDoc)).count();
+    assertEquals(expectedSize, actualSize);
+    assertEquals(expectedSize, count);
+  }
 }

--- a/document-store/src/integrationTest/resources/mongo/test_aggr_alias_distinct_count_response.json
+++ b/document-store/src/integrationTest/resources/mongo/test_aggr_alias_distinct_count_response.json
@@ -5,6 +5,11 @@
     "price":20
   },
   {
+    "item":"Soap",
+    "qty_count":2,
+    "price":10
+  },
+  {
     "item":"Mirror",
     "qty_count":1,
     "price":20
@@ -13,10 +18,5 @@
     "item":"Comb",
     "qty_count":2,
     "price":7.5
-  },
-  {
-    "item":"Soap",
-    "qty_count":2,
-    "price":10
   }
 ]

--- a/document-store/src/integrationTest/resources/mongo/test_nest_field_filter_response.json
+++ b/document-store/src/integrationTest/resources/mongo/test_nest_field_filter_response.json
@@ -1,103 +1,17 @@
 [
   {
-    "date":"2014-03-01T08:00:00Z",
-    "item":"Soap",
-    "price":10,
+    "date":"2015-09-10T08:43:00Z",
+    "item":"Comb",
+    "price":7.5,
     "props":{
-      "size":"M",
-      "brand":"Dettol",
       "seller":{
-        "name":"Metro Chemicals Pvt. Ltd.",
-        "address":{
-          "city":"Mumbai",
-          "pincode":400004
-        }
-      }
-    },
-    "sales":[
-      {
-        "city":"delhi",
-        "medium":[
-          {
-            "type":"distributionChannel",
-            "volume":1000
-          },
-          {
-            "type":"retail",
-            "volume":500
-          },
-          {
-            "type":"online",
-            "volume":1000
-          }
-        ]
-      },
-      {
-        "city":"pune",
-        "medium":[
-          {
-            "type":"distributionChannel",
-            "volume":300
-          },
-          {
-            "type":"online",
-            "volume":2000
-          }
-        ]
-      }
-    ],
-    "quantity":2
-  },
-  {
-    "date":"2014-03-01T09:00:00Z",
-    "item":"Mirror",
-    "price":20,
-    "sales":[
-      {
-        "city":"delhi",
-        "medium":[
-
-        ]
-      }
-    ],
-    "quantity":1
-  },
-  {
-    "date":"2016-02-06T20:20:13Z",
-    "item":"Soap",
-    "price":10,
-    "quantity":5
-  },
-  {
-    "date":"2014-04-04T11:21:39.736Z",
-    "item":"Shampoo",
-    "price":5,
-    "sales":[
-
-    ],
-    "quantity":20
-  },
-  {
-    "date":"2014-04-04T21:23:13.331Z",
-    "item":"Soap",
-    "price":20,
-    "props":{
-      "size":"S",
-      "brand":"Lifebuoy",
-      "seller":{
-        "name":"Hans and Co.",
+        "name":"Go Go Plastics",
         "address":{
           "city":"Kolkata",
           "pincode":700007
         }
       }
     },
-    "quantity":5
-  },
-  {
-    "date":"2015-06-04T05:08:13Z",
-    "item":"Comb",
-    "price":7.5,
-    "quantity":5
+    "quantity":10
   }
 ]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
@@ -14,7 +14,6 @@ import org.hypertrace.core.documentstore.query.Pagination;
 import org.hypertrace.core.documentstore.query.Query;
 
 public class PostgresQueryParser {
-  private static String NOT_YET_SUPPORTED = "Not yet supported %s";
   private final String collection;
 
   @Getter private final Builder paramsBuilder = Params.newBuilder();
@@ -99,8 +98,9 @@ public class PostgresQueryParser {
   private Optional<String> parsePagination() {
     Optional<Pagination> pagination = this.query.getPagination();
     if (pagination.isPresent()) {
-      throw new UnsupportedOperationException(
-          String.format(NOT_YET_SUPPORTED, "pagination clause"));
+      this.paramsBuilder.addObjectParam(pagination.get().getOffset());
+      this.paramsBuilder.addObjectParam(pagination.get().getLimit());
+      return Optional.of("OFFSET ? LIMIT ?");
     }
     return Optional.empty();
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import lombok.Getter;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
+import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresAggregationFilterTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresFilterTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresGroupTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSelectTypeExpressionVisitor;
@@ -88,7 +89,7 @@ public class PostgresQueryParser {
   }
 
   private Optional<String> parseHaving() {
-    return PostgresFilterTypeExpressionVisitor.getAggregationFilterClause(this);
+    return PostgresAggregationFilterTypeExpressionVisitor.getAggregationFilterClause(this);
   }
 
   private Optional<String> parseOrderBy() {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregationFilterTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregationFilterTypeExpressionVisitor.java
@@ -1,0 +1,62 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.vistors;
+
+import java.util.Optional;
+import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
+import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
+import org.hypertrace.core.documentstore.expression.type.SelectTypeExpression;
+import org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
+
+public class PostgresAggregationFilterTypeExpressionVisitor
+    extends PostgresFilterTypeExpressionVisitor {
+
+  public PostgresAggregationFilterTypeExpressionVisitor(PostgresQueryParser postgresQueryParser) {
+    super(postgresQueryParser);
+  }
+
+  @Override
+  public String visit(final RelationalExpression expression) {
+    SelectTypeExpression lhs = expression.getLhs();
+    RelationalOperator operator = expression.getOperator();
+    SelectTypeExpression rhs = expression.getRhs();
+
+    // Only an identifier LHS and a constant RHS is supported as of now.
+    PostgresSelectTypeExpressionVisitor lhsVisitor = new PostgresIdentifierExpressionVisitor();
+    PostgresSelectTypeExpressionVisitor rhsVisitor = new PostgresConstantExpressionVisitor();
+
+    String key = lhs.accept(lhsVisitor);
+    Object value = rhs.accept(rhsVisitor);
+
+    // In SQL, the alias is not supported in the Filter and Having clause.
+    // As of now, where is clause is first parsed and it is not using any alias expression.
+    // However, having clause is parsed after group by, and currently, it is only
+    // supported with alias expression.
+
+    if (!postgresQueryParser.getPgSelections().containsKey(key)) {
+      throw new UnsupportedOperationException(
+          "Having clause is only supported with alias expression"
+              + "for aggregation and functional expression");
+    }
+    return PostgresUtils.prepareParsedNonCompositeFilter(
+        postgresQueryParser.getPgSelections().get(key),
+        operator.toString(),
+        value,
+        this.postgresQueryParser.getParamsBuilder());
+  }
+
+  public static Optional<String> getAggregationFilterClause(
+      PostgresQueryParser postgresQueryParser) {
+    return prepareFilterClause(
+        postgresQueryParser.getQuery().getAggregationFilter(), postgresQueryParser);
+  }
+
+  private static Optional<String> prepareFilterClause(
+      Optional<FilterTypeExpression> filterTypeExpression,
+      PostgresQueryParser postgresQueryParser) {
+    return filterTypeExpression.map(
+        expression ->
+            expression.accept(
+                new PostgresAggregationFilterTypeExpressionVisitor(postgresQueryParser)));
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresDataAccessorIdentifierExpressionVisitor.java
@@ -29,11 +29,6 @@ public class PostgresDataAccessorIdentifierExpressionVisitor
   @Override
   public String visit(final IdentifierExpression expression) {
     String dataAccessor = PostgresUtils.prepareFieldDataAccessorExpr(expression.getName());
-    if (type.equals(Type.NUMERIC)) {
-      return PostgresUtils.prepareCast(dataAccessor, 1);
-    } else if (type.equals(Type.BOOLEAN)) {
-      return PostgresUtils.prepareCast(dataAccessor, true);
-    }
-    return PostgresUtils.prepareCast(dataAccessor, "");
+    return PostgresUtils.prepareCast(dataAccessor, type);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
@@ -16,7 +16,7 @@ import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 
 public class PostgresFilterTypeExpressionVisitor implements FilterTypeExpressionVisitor {
 
-  private PostgresQueryParser postgresQueryParser;
+  protected PostgresQueryParser postgresQueryParser;
 
   public PostgresFilterTypeExpressionVisitor(PostgresQueryParser postgresQueryParser) {
     this.postgresQueryParser = postgresQueryParser;
@@ -48,29 +48,12 @@ public class PostgresFilterTypeExpressionVisitor implements FilterTypeExpression
     String key = lhs.accept(lhsVisitor);
     Object value = rhs.accept(rhsVisitor);
 
-    // In SQL, the alias is not supported in the Filter and Having clause.
-    // As of now, where is clause is first parsed and it is not using any alias expression
-    // However, having clause is parsed after group by, and the query can have alias expression.
-    // So, for alias expression in having clause, we are extracting it from previously parsed
-    // selection clause.
-    return postgresQueryParser.getPgSelections().containsKey(key)
-        ? PostgresUtils.prepareParsedNonCompositeFilter(
-            postgresQueryParser.getPgSelections().get(key),
-            operator.toString(),
-            value,
-            this.postgresQueryParser.getParamsBuilder())
-        : PostgresUtils.parseNonCompositeFilter(
-            key, operator.toString(), value, this.postgresQueryParser.getParamsBuilder());
+    return PostgresUtils.parseNonCompositeFilter(
+        key, operator.toString(), value, this.postgresQueryParser.getParamsBuilder());
   }
 
   public static Optional<String> getFilterClause(PostgresQueryParser postgresQueryParser) {
     return prepareFilterClause(postgresQueryParser.getQuery().getFilter(), postgresQueryParser);
-  }
-
-  public static Optional<String> getAggregationFilterClause(
-      PostgresQueryParser postgresQueryParser) {
-    return prepareFilterClause(
-        postgresQueryParser.getQuery().getAggregationFilter(), postgresQueryParser);
   }
 
   private static Optional<String> prepareFilterClause(

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -95,10 +95,7 @@ public class PostgresUtils {
     } else if (type.equals(Type.BOOLEAN)) {
       return String.format(fmt, field, type);
     } else {
-      // default is string
-      // Note: As we are using field accessor pattern, we are casting String too.
-      // See more details on method : prepareParsedNonCompositeFilter
-      return String.format(fmt, field, type);
+      return prepareFieldDataAccessorExpr(field);
     }
   }
 
@@ -223,9 +220,9 @@ public class PostgresUtils {
    * part of the below method, we are only using field accessor pattern. This method will be used in
    * Having / Where clause perperation.
    *
-   * <p>See the corresponding test at {@link
-   * PostgresQueryParserTest.testAggregationFilterAlongWithNonAliasFields} In the above example,
-   * check how the price is accessed using -> instead of ->>.
+   * <p>See the corresponding test at
+   * PostgresQueryParserTest.testAggregationFilterAlongWithNonAliasFields.
+   * In the above example, check how the price is accessed using -> instead of ->>.
    */
   public static String prepareParsedNonCompositeFilter(
       String preparedExpression, String op, Object value, Builder paramsBuilder) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -94,8 +94,8 @@ public class PostgresUtils {
       return String.format(fmt, field, type);
     } else if (type.equals(Type.BOOLEAN)) {
       return String.format(fmt, field, type);
-    } else {
-      return prepareFieldDataAccessorExpr(field);
+    } else /* default is string */ {
+      return field;
     }
   }
 
@@ -114,7 +114,7 @@ public class PostgresUtils {
 
   public static String parseNonCompositeFilter(
       String fieldName, String op, Object value, Builder paramsBuilder) {
-    String fullFieldName = prepareCast(prepareFieldAccessorExpr(fieldName).toString(), value);
+    String fullFieldName = prepareCast(prepareFieldDataAccessorExpr(fieldName), value);
     StringBuilder filterString = new StringBuilder(fullFieldName);
     String sqlOperator;
     Boolean isMultiValued = false;
@@ -221,8 +221,8 @@ public class PostgresUtils {
    * Having / Where clause perperation.
    *
    * <p>See the corresponding test at
-   * PostgresQueryParserTest.testAggregationFilterAlongWithNonAliasFields.
-   * In the above example, check how the price is accessed using -> instead of ->>.
+   * PostgresQueryParserTest.testAggregationFilterAlongWithNonAliasFields. In the above example,
+   * check how the price is accessed using -> instead of ->>.
    */
   public static String prepareParsedNonCompositeFilter(
       String preparedExpression, String op, Object value, Builder paramsBuilder) {

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -52,7 +52,7 @@ public class PostgresQueryParserTest {
     String sql = postgresQueryParser.parse();
     Assertions.assertEquals(
         "SELECT * FROM testCollection "
-            + "WHERE document->'quantity' IS NULL OR CAST (document->'quantity' AS NUMERIC) != ?",
+            + "WHERE document->'quantity' IS NULL OR CAST (document->>'quantity' AS NUMERIC) != ?",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -71,7 +71,7 @@ public class PostgresQueryParserTest {
                             IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
                     .operand(
                         RelationalExpression.of(
-                            IdentifierExpression.of("props.address.city"),
+                            IdentifierExpression.of("props.seller.address.city"),
                             EQ,
                             ConstantExpression.of("Kolkata")))
                     .build())
@@ -80,8 +80,8 @@ public class PostgresQueryParserTest {
     String sql = postgresQueryParser.parse();
     Assertions.assertEquals(
         "SELECT * FROM testCollection "
-            + "WHERE (CAST (document->'quantity' AS NUMERIC) > ?) "
-            + "AND (CAST (document->'props'->'address'->'city' AS STRING) = ?)",
+            + "WHERE (CAST (document->>'quantity' AS NUMERIC) > ?) "
+            + "AND (document->'props'->'seller'->'address'->>'city' = ?)",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -107,8 +107,8 @@ public class PostgresQueryParserTest {
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION, query);
     String sql = postgresQueryParser.parse();
     Assertions.assertEquals(
-        "SELECT * FROM testCollection WHERE (CAST (document->'quantity' AS NUMERIC) >= ?) "
-            + "AND (CAST (document->'quantity' AS NUMERIC) <= ?)",
+        "SELECT * FROM testCollection WHERE (CAST (document->>'quantity' AS NUMERIC) >= ?) "
+            + "AND (CAST (document->>'quantity' AS NUMERIC) <= ?)",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -134,8 +134,8 @@ public class PostgresQueryParserTest {
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION, query);
     String sql = postgresQueryParser.parse();
     Assertions.assertEquals(
-        "SELECT * FROM testCollection WHERE (CAST (document->'quantity' AS NUMERIC) >= ?) "
-            + "OR (CAST (document->'quantity' AS NUMERIC) <= ?)",
+        "SELECT * FROM testCollection WHERE (CAST (document->>'quantity' AS NUMERIC) >= ?) "
+            + "OR (CAST (document->>'quantity' AS NUMERIC) <= ?)",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -173,9 +173,9 @@ public class PostgresQueryParserTest {
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION, query);
     String sql = postgresQueryParser.parse();
     Assertions.assertEquals(
-        "SELECT * FROM testCollection WHERE (CAST (document->'price' AS NUMERIC) >= ?) "
-            + "AND ((CAST (document->'quantity' AS NUMERIC) >= ?) "
-            + "OR (CAST (document->'quantity' AS NUMERIC) <= ?))",
+        "SELECT * FROM testCollection WHERE (CAST (document->>'price' AS NUMERIC) >= ?) "
+            + "AND ((CAST (document->>'quantity' AS NUMERIC) >= ?) "
+            + "OR (CAST (document->>'quantity' AS NUMERIC) <= ?))",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -314,7 +314,7 @@ public class PostgresQueryParserTest {
             + "SUM( CAST (document->>'quantity' AS NUMERIC) ) AS qty_sum, "
             + "MIN( CAST (document->>'quantity' AS NUMERIC) ) AS qty_min, "
             + "MAX( CAST (document->>'quantity' AS NUMERIC) ) AS qty_max "
-            + "FROM testCollection WHERE CAST (document->'price' AS NUMERIC) = ? "
+            + "FROM testCollection WHERE CAST (document->>'price' AS NUMERIC) = ? "
             + "GROUP BY document->'item'",
         sql);
 
@@ -391,7 +391,7 @@ public class PostgresQueryParserTest {
     Assertions.assertEquals(
         "SELECT COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) AS qty_count, "
             + "document->'item' AS item FROM testCollection "
-            + "WHERE CAST (document->'price' AS NUMERIC) <= ? "
+            + "WHERE CAST (document->>'price' AS NUMERIC) <= ? "
             + "GROUP BY document->'item' "
             + "HAVING COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) <= ?",
         sql);
@@ -425,21 +425,7 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION, query);
-    String sql = postgresQueryParser.parse();
-
-    Assertions.assertEquals(
-        "SELECT COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) AS qty_count, "
-            + "document->'item' AS item, "
-            + "document->'price' AS price "
-            + "FROM testCollection "
-            + "GROUP BY document->'item',document->'price' "
-            + "HAVING (COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) <= ?) "
-            + "AND (CAST (document->'price' AS NUMERIC) > ?)",
-        sql);
-
-    Params params = postgresQueryParser.getParamsBuilder().build();
-    Assertions.assertEquals(10, params.getObjectParams().get(1));
-    Assertions.assertEquals(5, params.getObjectParams().get(2));
+    Assertions.assertThrows(UnsupportedOperationException.class, () -> postgresQueryParser.parse());
   }
 
   @Test
@@ -542,7 +528,7 @@ public class PostgresQueryParserTest {
             + "document->'quantity' AS quantity, "
             + "document->'date' AS date "
             + "FROM testCollection "
-            + "WHERE CAST (document->'item' AS STRING) IN (?, ?, ?, ?) "
+            + "WHERE document->>'item' IN (?, ?, ?, ?) "
             + "ORDER BY document->'quantity' DESC,document->'item' ASC "
             + "OFFSET ? LIMIT ?",
         sql);


### PR DESCRIPTION
As part of the supporting ticket: https://github.com/hypertrace/document-store/issues/82,  

This is the `seventh` PR in the series. It takes care of 
- supporting pagination clause
- adds unit test + integration tests
- pl. see the below notes for reverting back to the data accessor pattern `->>` in filter clause
- Restricting `Having` clause for only aggregation (not allowing non-alias field)

Note:
In the previous PR - https://github.com/hypertrace/document-store/pull/96, we have moved to field base accessor `->` in Where clase. However, it has some issues with text-based filters. So, as part of this PR, we are reverting back. 

Below is the example of query that were not working with field accessor (and there is not alternative for now):
```
SELECT document->'item' AS item, 
document->'price' AS price, 
document->'quantity' AS quantity, 
document->'date' AS date 
FROM myTest 
WHERE document->'item' IN ('Mirror', 'Comb', 'Shampoo', 'Bottle') 
ORDER BY document->'quantity' DESC,document->'item' ASC OFFSET 1 LIMIT 3
```

Example of query that doesn't work in `Having` clause without field accessor,  so restricting it. As we can add the same clauses in the filter for now.
```
SELECT COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) AS qty_count, 
document->'item' AS item, 
document->'price' AS price 
FROM myTest 
GROUP BY document->'item',document->'price' 
HAVING (COUNT(DISTINCT CAST (document->>'quantity' AS NUMERIC) ) <= 10) 
AND (document->'price' IN ('Mirror', 'Comb', 'Shampoo', 'Bottle'))
```