### PR TITLE
fix: fixed few more mongo specific tests

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -652,6 +652,44 @@ public class DocStoreQueryV1Test {
 
   @ParameterizedTest
   @MethodSource("databaseContextBoth")
+  public void testQueryQ1AggregationFilterWithStringInFilterAlongWithNonAliasFields(
+      String dataStoreName) throws IOException {
+    Datastore datastore = datastoreMap.get(dataStoreName);
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(
+                AggregateExpression.of(DISTINCT_COUNT, IdentifierExpression.of("quantity")),
+                "qty_count")
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("price"))
+            .addAggregation(IdentifierExpression.of("item"))
+            .addAggregation(IdentifierExpression.of("price"))
+            .setAggregationFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("qty_count"), LTE, ConstantExpression.of(10)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("item"),
+                            IN,
+                            ConstantExpression.ofStrings(
+                                List.of("Mirror", "Comb", "Shampoo", "Bottle"))))
+                    .build())
+            .build();
+
+    Iterator<Document> resultDocs = collection.aggregate(query);
+    Utils.assertDocsAndSizeEqualWithoutOrder(
+        dataStoreName,
+        resultDocs,
+        3,
+        "mongo/test_string_in_filter_aggr_alias_distinct_count_response.json");
+  }
+
+  @ParameterizedTest
+  @MethodSource("databaseContextBoth")
   public void testQueryV1ForSimpleWhereClause(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);

--- a/document-store/src/integrationTest/resources/mongo/pg_aggregate_on_nested_fields_response.json
+++ b/document-store/src/integrationTest/resources/mongo/pg_aggregate_on_nested_fields_response.json
@@ -1,0 +1,23 @@
+[
+  {
+    "num_items":{
+      "value":4
+    }
+  },
+  {
+    "pincode":{
+      "value":700007
+    },
+    "num_items":{
+      "value":2
+    }
+  },
+  {
+    "pincode":{
+      "value":400004
+    },
+    "num_items":{
+      "value":2
+    }
+  }
+]

--- a/document-store/src/integrationTest/resources/mongo/test_string_aggr_alias_distinct_count_response.json
+++ b/document-store/src/integrationTest/resources/mongo/test_string_aggr_alias_distinct_count_response.json
@@ -1,0 +1,12 @@
+[
+  {
+    "item":"Soap",
+    "qty_count":2,
+    "price":10
+  },
+  {
+    "item":"Soap",
+    "qty_count":1,
+    "price":20
+  }
+]

--- a/document-store/src/integrationTest/resources/mongo/test_string_in_filter_aggr_alias_distinct_count_response.json
+++ b/document-store/src/integrationTest/resources/mongo/test_string_in_filter_aggr_alias_distinct_count_response.json
@@ -1,0 +1,17 @@
+[
+  {
+    "item":"Comb",
+    "qty_count":2,
+    "price":7.5
+  },
+  {
+    "item":"Shampoo",
+    "qty_count":2,
+    "price":5
+  },
+  {
+    "item":"Mirror",
+    "qty_count":1,
+    "price":20
+  }
+]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
@@ -52,7 +52,7 @@ public class PostgresAggregateExpressionVisitor extends PostgresSelectTypeExpres
             ? stringTypeDataAccessorVisitor
             : numericTypeDataAccessorVisitor;
 
-    String value = expression.getExpression().accept(selectTypeExpressionVisitor);
+    String value = expression.getExpression().accept(selectTypeExpressionVisitor).toString();
     return value != null ? convertToAggregationFunction(operator, value) : null;
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -303,7 +303,7 @@ public class PostgresUtils {
   }
 
   public static boolean isEncodedNestedField(String fieldName) {
-    return fieldName.contains(DOT_STR) ? true : false;
+    return fieldName.contains(DOT_STR) || fieldName.contains(DOT) ? true : false;
   }
 
   public static String encodeAliasForNestedField(String nestedFieldName) {

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -431,7 +431,21 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser = new PostgresQueryParser(TEST_COLLECTION, query);
-    Assertions.assertThrows(UnsupportedOperationException.class, () -> postgresQueryParser.parse());
+    String sql = postgresQueryParser.parse();
+
+    Assertions.assertEquals(
+        "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
+            + "document->'item' AS item, "
+            + "document->'price' AS price "
+            + "FROM testCollection "
+            + "GROUP BY document->'item',document->'price' "
+            + "HAVING (COUNT(DISTINCT document->>'quantity' ) <= ?) AND (CAST (document->'price' AS NUMERIC) > ?)",
+        sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    Assertions.assertEquals(2, params.getObjectParams().size());
+    Assertions.assertEquals(10, params.getObjectParams().get(1));
+    Assertions.assertEquals(5, params.getObjectParams().get(2));
   }
 
   @Test


### PR DESCRIPTION
As part of the supporting ticket: https://github.com/hypertrace/document-store/issues/82,  

This is the follow-up PR. It takes care of,
- fixed all the tests that were marked only for mongo context except one.
    -  DISTINCT with Groupby is not supported on postgres impl as of now.
- allows fields accessor along with expression in having clause (aggregation filter)
- rewrite count API using sub-query as discussed here - https://github.com/hypertrace/document-store/pull/106#discussion_r926563000