### PR TITLE
feat: add support for distinct aggregator operation and length functional operator

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -556,7 +556,7 @@ public class DocStoreQueryV1Test {
   }
 
   @ParameterizedTest
-  @MethodSource("databaseContextPostgres")
+  @MethodSource("databaseContextBoth")
   public void testAggregateWithMultipleGroupingLevels(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -556,7 +556,7 @@ public class DocStoreQueryV1Test {
   }
 
   @ParameterizedTest
-  @MethodSource("databaseContextMongo")
+  @MethodSource("databaseContextPostgres")
   public void testAggregateWithMultipleGroupingLevels(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);
@@ -567,13 +567,13 @@ public class DocStoreQueryV1Test {
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
             .addSelection(
+                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
+            .addSelection(
                 FunctionExpression.builder()
                     .operator(LENGTH)
                     .operand(IdentifierExpression.of("quantities"))
                     .build(),
                 "num_quantities")
-            .addSelection(
-                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
             .setAggregationFilter(
                 RelationalExpression.of(
                     IdentifierExpression.of("num_quantities"), EQ, ConstantExpression.of(1)))

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
@@ -3,7 +3,7 @@ package org.hypertrace.core.documentstore.expression.operators;
 public enum AggregationOperator {
   AVG,
   COUNT,
-  DISTINCT,
+  DISTINCT, // This operator generates an array of distinct values
   DISTINCT_COUNT,
   SUM,
   MIN,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/FunctionOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/FunctionOperator.java
@@ -4,7 +4,8 @@ public enum FunctionOperator {
   // Unary operations
   ABS,
   FLOOR,
-  LENGTH,
+  LENGTH, // This operator returns the length of an array,
+  // use along with DISTINCT of aggregation operator
 
   // n-ary operations
   ADD,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -985,7 +985,11 @@ public class PostgresCollection implements Collection {
       Map<String, Object> jsonNode = new HashMap();
       for (int i = 1; i <= columnCount; i++) {
         String columnName = resultSetMetaData.getColumnName(i);
-        String columnValue = resultSet.getString(i);
+        int columnType = resultSetMetaData.getColumnType(i);
+        String columnValue =
+            columnType == 2003
+                ? MAPPER.writeValueAsString(resultSet.getArray(i).getArray())
+                : resultSet.getString(i);
         if (StringUtils.isNotEmpty(columnValue)) {
           JsonNode leafNodeValue = MAPPER.readTree(columnValue);
           if (PostgresUtils.isEncodedNestedField(columnName)) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
@@ -59,6 +59,8 @@ public class PostgresAggregateExpressionVisitor extends PostgresSelectTypeExpres
   private String convertToAggregationFunction(AggregationOperator operator, String value) {
     if (operator.equals(AggregationOperator.DISTINCT_COUNT)) {
       return String.format("COUNT(DISTINCT %s )", value);
+    } else if (operator.equals(AggregationOperator.DISTINCT)) {
+      return String.format("ARRAY_AGG(DISTINCT %s)", value);
     }
     return String.format("%s( %s )", operator, value);
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresGroupTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresGroupTypeExpressionVisitor.java
@@ -4,10 +4,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.operators.AggregationOperator;
 import org.hypertrace.core.documentstore.expression.type.GroupTypeExpression;
 import org.hypertrace.core.documentstore.parser.GroupTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser;
@@ -36,10 +34,6 @@ public class PostgresGroupTypeExpressionVisitor implements GroupTypeExpressionVi
     Query query = postgresQueryParser.getQuery();
     if (query.getAggregations().size() <= 0) return null;
 
-    if (!validate(query)) {
-      throw new UnsupportedOperationException("Group By clause with DISTINCT is not yet supported");
-    }
-
     List<GroupTypeExpression> groupTypeExpressions = query.getAggregations();
 
     PostgresGroupTypeExpressionVisitor groupTypeExpressionVisitor =
@@ -54,15 +48,5 @@ public class PostgresGroupTypeExpressionVisitor implements GroupTypeExpressionVi
             .collect(Collectors.joining(","));
 
     return !childList.isEmpty() ? childList : null;
-  }
-
-  private static boolean validate(Query query) {
-    return !query.getSelections().stream()
-        .filter(exp -> exp.getExpression() instanceof AggregateExpression)
-        .anyMatch(
-            exp ->
-                ((AggregateExpression) exp.getExpression())
-                    .getAggregator()
-                    .equals(AggregationOperator.DISTINCT));
   }
 }


### PR DESCRIPTION
As part of the supporting ticket: https://github.com/hypertrace/document-store/issues/82,  

In the prior PR, we didn't have support for distinct aggregation operator and length functional operator.
See the test - `testAggregateWithMultipleGroupingLevels` in `DocStoreQueryV1Test` was marked only for MongoContext.

As part of this PR,
- adds support for distinct aggregation operator and functional length operator
   - Both the above operator works on array type:
       - distinct aggregation operator prepare a set
       - length operator returns the size of the array
   - In the Postgres, `distinct` is mapped to `array_agg` function, and `length` is mapped to `array_length

Example of transformed query:
```
SELECT document->'item' AS item, 
document->'price' AS price, 
ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)) AS "quantities", 
ARRAY_LENGTH( ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)), 1 ) AS "num_quantities" 
FROM testCollection 
GROUP BY document->'item',document->'price' 
HAVING ARRAY_LENGTH( ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)), 1 ) = 1
ORDER BY document->'item' DESC
```

Note:
In postgres context, alias expression should appear prior in the selection list before using it in expression.

e.g  valid query:
```
Query query =
        Query.builder()
            .addAggregation(IdentifierExpression.of("item"))
            .addAggregation(IdentifierExpression.of("price"))
            .addSelection(IdentifierExpression.of("item"))
            .addSelection(IdentifierExpression.of("price"))
            .addSelection(
                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
            .addSelection(
                FunctionExpression.builder()
                    .operator(LENGTH)
                    .operand(IdentifierExpression.of("quantities"))
                    .build(),
                "num_quantities")
            .setAggregationFilter(
                RelationalExpression.of(
                    IdentifierExpression.of("num_quantities"), EQ, ConstantExpression.of(1)))
            .addSort(IdentifierExpression.of("item"), DESC)
            .build();
```

e.g invalid query: see the length expression uses an alias but it was defined in query later.
```
Query query =
        Query.builder()
            .addAggregation(IdentifierExpression.of("item"))
            .addAggregation(IdentifierExpression.of("price"))
            .addSelection(IdentifierExpression.of("item"))
            .addSelection(IdentifierExpression.of("price"))
            .addSelection(
                FunctionExpression.builder()
                    .operator(LENGTH)
                    .operand(IdentifierExpression.of("quantities"))
                    .build(),
                "num_quantities")
            .addSelection(
                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
            .setAggregationFilter(
                RelationalExpression.of(
                    IdentifierExpression.of("num_quantities"), EQ, ConstantExpression.of(1)))
            .addSort(IdentifierExpression.of("item"), DESC)
            .build();
```

