### PR TITLE
feat: add supports for createTime and lastUpdatedTime in postgresql

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -178,10 +178,6 @@ public class DocStoreTest {
     assertEquals(createdTime, newCreatedTime);
     Object newLastUpdatedTime = getLastUpdatedTime(persistedDocument, dataStoreName);
     Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
-    //    if (isMongo(dataStoreName)) {
-    //      // todo: for postgres lastUpdated time is same as previous
-    //      Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
-    //    }
   }
 
   @ParameterizedTest

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -178,10 +178,10 @@ public class DocStoreTest {
     assertEquals(createdTime, newCreatedTime);
     Object newLastUpdatedTime = getLastUpdatedTime(persistedDocument, dataStoreName);
     Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
-//    if (isMongo(dataStoreName)) {
-//      // todo: for postgres lastUpdated time is same as previous
-//      Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
-//    }
+    //    if (isMongo(dataStoreName)) {
+    //      // todo: for postgres lastUpdated time is same as previous
+    //      Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
+    //    }
   }
 
   @ParameterizedTest
@@ -346,7 +346,7 @@ public class DocStoreTest {
   }
 
   @ParameterizedTest
-  @MethodSource("databaseContextProvider")
+  @MethodSource("databaseContextPostgres")
   public void testNotEquals(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     datastore.createCollection(COLLECTION_NAME, null);
@@ -2467,23 +2467,23 @@ public class DocStoreTest {
   static Object getCreatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
     return node.findValue(DocStoreConstants.CREATED_TIME).asLong();
-//    if (isMongo(dataStoreName)) {
-//      return node.findValue(MONGO_CREATED_TIME_KEY).asLong();
-//    } else if (isPostgress(dataStoreName)) {
-//      return node.findValue(POSTGRES_CREATED_AT).asText();
-//    }
-//    return "";
+    //    if (isMongo(dataStoreName)) {
+    //      return node.findValue(MONGO_CREATED_TIME_KEY).asLong();
+    //    } else if (isPostgress(dataStoreName)) {
+    //      return node.findValue(POSTGRES_CREATED_AT).asText();
+    //    }
+    //    return "";
   }
 
   static Object getLastUpdatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
     return node.findValue(DocStoreConstants.LAST_UPDATED_TIME).asLong();
-//    if (isMongo(dataStoreName)) {
-//      return node.findValue(MONGO_LAST_UPDATE_TIME_KEY).findValue("$date").asText();
-//    } else if (isPostgress(dataStoreName)) {
-//      return node.findValue(POSTGRES_UPDATED_AT).asText();
-//    }
-//    return "";
+    //    if (isMongo(dataStoreName)) {
+    //      return node.findValue(MONGO_LAST_UPDATE_TIME_KEY).findValue("$date").asText();
+    //    } else if (isPostgress(dataStoreName)) {
+    //      return node.findValue(POSTGRES_UPDATED_AT).asText();
+    //    }
+    //    return "";
   }
 
   static String getId(String dataStoreName) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -129,8 +129,18 @@ public class DocStoreTest {
     return Stream.of(Arguments.of(MONGO_STORE), Arguments.of(POSTGRES_STORE));
   }
 
+  @MethodSource
+  private static Stream<Arguments> databaseContextPostgres() {
+    return Stream.of(Arguments.of(POSTGRES_STORE));
+  }
+
+  @MethodSource
+  private static Stream<Arguments> databaseContextMongo() {
+    return Stream.of(Arguments.of(MONGO_STORE));
+  }
+
   @ParameterizedTest
-  @MethodSource("databaseContextProvider")
+  @MethodSource("databaseContextPostgres")
   public void testUpsert(String dataStoreName) throws Exception {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);
@@ -167,10 +177,11 @@ public class DocStoreTest {
     Object newCreatedTime = getCreatedTime(persistedDocument, dataStoreName);
     assertEquals(createdTime, newCreatedTime);
     Object newLastUpdatedTime = getLastUpdatedTime(persistedDocument, dataStoreName);
-    if (isMongo(dataStoreName)) {
-      // todo: for postgres lastUpdated time is same as previous
-      Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
-    }
+    Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
+//    if (isMongo(dataStoreName)) {
+//      // todo: for postgres lastUpdated time is same as previous
+//      Assertions.assertNotEquals(lastUpdatedTime, newLastUpdatedTime);
+//    }
   }
 
   @ParameterizedTest
@@ -2455,22 +2466,24 @@ public class DocStoreTest {
 
   static Object getCreatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
-    if (isMongo(dataStoreName)) {
-      return node.findValue(MONGO_CREATED_TIME_KEY).asLong();
-    } else if (isPostgress(dataStoreName)) {
-      return node.findValue(POSTGRES_CREATED_AT).asText();
-    }
-    return "";
+    return node.findValue(DocStoreConstants.CREATED_TIME).asLong();
+//    if (isMongo(dataStoreName)) {
+//      return node.findValue(MONGO_CREATED_TIME_KEY).asLong();
+//    } else if (isPostgress(dataStoreName)) {
+//      return node.findValue(POSTGRES_CREATED_AT).asText();
+//    }
+//    return "";
   }
 
   static Object getLastUpdatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
-    if (isMongo(dataStoreName)) {
-      return node.findValue(MONGO_LAST_UPDATE_TIME_KEY).findValue("$date").asText();
-    } else if (isPostgress(dataStoreName)) {
-      return node.findValue(POSTGRES_UPDATED_AT).asText();
-    }
-    return "";
+    return node.findValue(DocStoreConstants.LAST_UPDATED_TIME).asLong();
+//    if (isMongo(dataStoreName)) {
+//      return node.findValue(MONGO_LAST_UPDATE_TIME_KEY).findValue("$date").asText();
+//    } else if (isPostgress(dataStoreName)) {
+//      return node.findValue(POSTGRES_UPDATED_AT).asText();
+//    }
+//    return "";
   }
 
   static String getId(String dataStoreName) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -140,7 +140,7 @@ public class DocStoreTest {
   }
 
   @ParameterizedTest
-  @MethodSource("databaseContextPostgres")
+  @MethodSource("databaseContextProvider")
   public void testUpsert(String dataStoreName) throws Exception {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);
@@ -346,7 +346,7 @@ public class DocStoreTest {
   }
 
   @ParameterizedTest
-  @MethodSource("databaseContextPostgres")
+  @MethodSource("databaseContextProvider")
   public void testNotEquals(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     datastore.createCollection(COLLECTION_NAME, null);
@@ -2467,23 +2467,11 @@ public class DocStoreTest {
   static Object getCreatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
     return node.findValue(DocStoreConstants.CREATED_TIME).asLong();
-    //    if (isMongo(dataStoreName)) {
-    //      return node.findValue(MONGO_CREATED_TIME_KEY).asLong();
-    //    } else if (isPostgress(dataStoreName)) {
-    //      return node.findValue(POSTGRES_CREATED_AT).asText();
-    //    }
-    //    return "";
   }
 
   static Object getLastUpdatedTime(String doc, String dataStoreName) throws Exception {
     JsonNode node = OBJECT_MAPPER.readTree(doc);
     return node.findValue(DocStoreConstants.LAST_UPDATED_TIME).asLong();
-    //    if (isMongo(dataStoreName)) {
-    //      return node.findValue(MONGO_LAST_UPDATE_TIME_KEY).findValue("$date").asText();
-    //    } else if (isPostgress(dataStoreName)) {
-    //      return node.findValue(POSTGRES_UPDATED_AT).asText();
-    //    }
-    //    return "";
   }
 
   static String getId(String dataStoreName) {

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.hypertrace.core.documentstore.Filter.Op;
+import org.hypertrace.core.documentstore.commons.DocStoreConstants;
 import org.hypertrace.core.documentstore.mongo.MongoDatastore;
 import org.hypertrace.core.documentstore.postgres.PostgresDatastore;
 import org.hypertrace.core.documentstore.utils.CreateUpdateTestThread;
@@ -672,6 +673,8 @@ public class DocStoreTest {
     } else if (isPostgress(dataStoreName)) {
       jsonNode.remove(POSTGRES_CREATED_AT);
       jsonNode.remove(POSTGRES_UPDATED_AT);
+      jsonNode.remove(DocStoreConstants.CREATED_TIME);
+      jsonNode.remove(DocStoreConstants.LAST_UPDATED_TIME);
     }
     Assertions.assertEquals(expected, OBJECT_MAPPER.writeValueAsString(jsonNode));
   }

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/utils/Utils.java
@@ -20,6 +20,7 @@ import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.Key;
 import org.hypertrace.core.documentstore.SingleValueKey;
+import org.hypertrace.core.documentstore.commons.DocStoreConstants;
 import org.hypertrace.core.documentstore.mongo.MongoCollection;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 
@@ -172,6 +173,8 @@ public class Utils {
     } else if (isPostgress(dataStoreName)) {
       document.remove(POSTGRES_CREATED_AT);
       document.remove(POSTGRES_UPDATED_AT);
+      document.remove(DocStoreConstants.CREATED_TIME);
+      document.remove(DocStoreConstants.LAST_UPDATED_TIME);
     }
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/commons/DocStoreConstants.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/commons/DocStoreConstants.java
@@ -1,0 +1,6 @@
+package org.hypertrace.core.documentstore.commons;
+
+public class DocStoreConstants {
+  public static final String LAST_UPDATED_TIME = "lastUpdatedTime";
+  public static final String CREATED_TIME = "createdTime";
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -963,7 +963,7 @@ public class PostgresCollection implements Collection {
       PreparedStatement preparedStatement =
           client.prepareStatement(updateSubDocSQL, Statement.RETURN_GENERATED_KEYS);
       for (Key key : keys) {
-        preparedStatement.setLong(1, now);
+        preparedStatement.setString(1, "" + now);
         preparedStatement.setString(2, key.toString());
         preparedStatement.addBatch();
       }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -208,7 +208,7 @@ public class PostgresCollection implements Collection {
     if (result) {
       long updatedCount = updateLastModifiedTime(Set.of(key));
       if (updatedCount == 1) return true;
-      LOGGER.error("Failed in modifying last updated time for key:{}", key);
+      LOGGER.error("Failed in modifying lastUpdatedTime for key:{}", key);
     }
     return false;
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -40,6 +40,7 @@ import org.hypertrace.core.documentstore.Key;
 import org.hypertrace.core.documentstore.Query;
 import org.hypertrace.core.documentstore.SingleValueKey;
 import org.hypertrace.core.documentstore.UpdateResult;
+import org.hypertrace.core.documentstore.commons.DocStoreConstants;
 import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -895,6 +896,13 @@ public class PostgresCollection implements Collection {
 
     ObjectNode jsonNode = (ObjectNode) MAPPER.readTree(jsonString);
     jsonNode.put(DOCUMENT_ID, key.toString());
+
+    // update time fields
+    long now = System.currentTimeMillis();
+    JsonNode createdTime = jsonNode.get(DocStoreConstants.CREATED_TIME);
+    if (createdTime == null)
+      jsonNode.put(DocStoreConstants.CREATED_TIME, System.currentTimeMillis());
+    jsonNode.put(DocStoreConstants.LAST_UPDATED_TIME, now);
 
     return MAPPER.writeValueAsString(jsonNode);
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/internal/BulkUpdateSubDocsInternalResult.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/internal/BulkUpdateSubDocsInternalResult.java
@@ -1,0 +1,22 @@
+package org.hypertrace.core.documentstore.postgres.internal;
+
+import java.util.Set;
+import org.hypertrace.core.documentstore.Key;
+
+public class BulkUpdateSubDocsInternalResult {
+  private Set<Key> updatedDocuments;
+  private long totalUpdateCount;
+
+  public BulkUpdateSubDocsInternalResult(Set<Key> updatedDocuments, long totalUpdateCount) {
+    this.updatedDocuments = updatedDocuments;
+    this.totalUpdateCount = totalUpdateCount;
+  }
+
+  public Set<Key> getUpdatedDocuments() {
+    return updatedDocuments;
+  }
+
+  public long getTotalUpdateCount() {
+    return totalUpdateCount;
+  }
+}


### PR DESCRIPTION
Two different impl of doc-store had different ways of handling `createdTime` and `lastUpdatedTime`.
- Mongo: `createdTime` and `lastUpdatedTime` are interested as part of document
- Postgres: Had two outer columns called `created_at` and `updated_at` with column type timestampz.

The above differences was causing issues for exposing attributes pointing to `createdTime`.
e.g see below exception on postgres:
```
Caused by: java.lang.NullPointerException
        at org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresFieldIdentifierExpressionVisitor.visit(PostgresFieldIdentifierExpressionVisitor.java:32)
        at org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSortTypeExpressionVisitor.visit(PostgresSortTypeExpressionVisitor.java:51)
        at org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSortTypeExpressionVisitor.visit(PostgresSortTypeExpressionVisitor.java:15)
        at org.hypertrace.core.documentstore.expression.impl.IdentifierExpression.accept(IdentifierExpression.java:43)
        at org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSortTypeExpressionVisitor.lambda$getOrderByClause$0(PostgresSortTypeExpressionVisitor.java:64)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
        at org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresSortTypeExpressionVisitor.getOrderByClause(PostgresSortTypeExpressionVisitor.java:67)
        at org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser.parseOrderBy(PostgresQueryParser.java:126)
        at org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser.parse(PostgresQueryParser.java:87)
        at org.hypertrace.core.documentstore.postgres.PostgresCollection.executeQueryV1(PostgresCollection.java:725)
        at org.hypertrace.core.documentstore.postgres.PostgresCollection.aggregate(PostgresCollection.java:343)
        at org.hypertrace.entity.query.service.EntityQueryServiceImpl.searchDocuments(EntityQueryServiceImpl.java:252)
        at org.hypertrace.entity.query.service.EntityQueryServiceImpl.execute(EntityQueryServiceImpl.java:162)
        ... 13 more
```

Discussed alternative solutions with @suresh-prakash, and we decided for backward compatibility, postgres side as well we will ingest `createdTime` and `lastUpdatedTime` as part of document **for now**.

Later, we will support converter for epoch to timestampz for `created_at` and `updated_at` along with filtering support.

**Note:**
- Planning to do a few optimizations as follow-up PR.
- As part of this PR, adding functionality