### PR TITLE
feat: add selection support in older api

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -2098,6 +2099,25 @@ public class DocStoreTest {
         expected = "Un-supported object types in filter";
         assertTrue(exception.getMessage().contains(expected));
       }
+    }
+
+    // test for selections
+    {
+      Query query = new Query();
+      query.addSelection("entityId");
+      query.addSelection("entityType");
+      query.setFilter(new Filter(Filter.Op.EQ, "_id", key1.toString()));
+      Iterator<Document> results = collection.search(query);
+      List<Document> documents = new ArrayList<>();
+      while (results.hasNext()) {
+        documents.add(results.next());
+      }
+      Assertions.assertEquals(1, documents.size());
+      Map<String, String> result =
+          OBJECT_MAPPER.readValue(documents.get(0).toJson(), new TypeReference<>() {});
+      Assertions.assertEquals(2, result.size());
+      Assertions.assertEquals("SERVICE", result.get("entityType"));
+      Assertions.assertEquals("e3ffc6f0-fc92-3a9c-9fa0-26269184d1aa", result.get("entityId"));
     }
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -1108,8 +1108,7 @@ public class PostgresCollection implements Collection {
       }
 
       // check for ID column
-      if (PostgresUtils.OUTER_COLUMNS.contains(columnName)
-          && columnName.equals(PostgresUtils.ID_COLUMN)) {
+      if (columnName.equals(ID)) {
         return MAPPER.writeValueAsString(resultSet.getString(columnIndex));
       }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -360,7 +360,7 @@ public class PostgresCollection implements Collection {
     try {
       PreparedStatement preparedStatement =
           buildPreparedStatement(pgSqlQuery, paramsBuilder.build());
-      LOGGER.warn("Executing search query to PostgresSQL:{}", preparedStatement.toString());
+      LOGGER.debug("Executing search query to PostgresSQL:{}", preparedStatement.toString());
       ResultSet resultSet = preparedStatement.executeQuery();
       CloseableIterator closeableIterator =
           query.getSelections().size() > 0
@@ -786,7 +786,7 @@ public class PostgresCollection implements Collection {
     try {
       PreparedStatement preparedStatement =
           buildPreparedStatement(sqlQuery, queryParser.getParamsBuilder().build());
-      LOGGER.warn("Executing executeQueryV1 sqlQuery:{}", preparedStatement.toString());
+      LOGGER.debug("Executing executeQueryV1 sqlQuery:{}", preparedStatement.toString());
       ResultSet resultSet = preparedStatement.executeQuery();
       CloseableIterator closeableIterator =
           query.getSelections().size() > 0

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -785,7 +785,7 @@ public class PostgresCollection implements Collection {
     try {
       PreparedStatement preparedStatement =
           buildPreparedStatement(sqlQuery, queryParser.getParamsBuilder().build());
-      LOGGER.warn("Executing executeQueryV1 query:{}", preparedStatement.toString());
+      LOGGER.warn("Executing executeQueryV1 sqlQuery:{}", preparedStatement.toString());
       ResultSet resultSet = preparedStatement.executeQuery();
       CloseableIterator closeableIterator =
           query.getSelections().size() > 0

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.documentstore.postgres;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -1083,11 +1084,7 @@ public class PostgresCollection implements Collection {
       Map<String, Object> jsonNode = new HashMap();
       for (int i = 1; i <= columnCount; i++) {
         String columnName = resultSetMetaData.getColumnName(i);
-        int columnType = resultSetMetaData.getColumnType(i);
-        String columnValue =
-            columnType == Types.ARRAY
-                ? MAPPER.writeValueAsString(resultSet.getArray(i).getArray())
-                : resultSet.getString(i);
+        String columnValue = getColumnValue(resultSetMetaData, columnName, i);
         if (StringUtils.isNotEmpty(columnValue)) {
           JsonNode leafNodeValue = MAPPER.readTree(columnValue);
           if (PostgresUtils.isEncodedNestedField(columnName)) {
@@ -1099,6 +1096,25 @@ public class PostgresCollection implements Collection {
         }
       }
       return new JSONDocument(MAPPER.writeValueAsString(jsonNode));
+    }
+
+    private String getColumnValue(
+        ResultSetMetaData resultSetMetaData, String columnName, int columnIndex)
+        throws SQLException, JsonProcessingException {
+      int columnType = resultSetMetaData.getColumnType(columnIndex);
+      // check for array
+      if (columnType == Types.ARRAY) {
+        return MAPPER.writeValueAsString(resultSet.getArray(columnIndex).getArray());
+      }
+
+      // check for ID column
+      if (PostgresUtils.OUTER_COLUMNS.contains(columnName)
+          && columnName.equals(PostgresUtils.ID_COLUMN)) {
+        return MAPPER.writeValueAsString(resultSet.getString(columnIndex));
+      }
+
+      // rest of the columns
+      return resultSet.getString(columnIndex);
     }
 
     private void handleNestedField(

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresCollection.java
@@ -750,7 +750,7 @@ public class PostgresCollection implements Collection {
   private CloseableIterator<Document> searchDocsForKeys(Set<Key> keys) {
     List<String> keysAsStr = keys.stream().map(Key::toString).collect(Collectors.toList());
     Query query =
-        new Query().withSelection("*").withFilter(new Filter(Filter.Op.IN, ID, keysAsStr));
+        new Query().withFilter(new Filter(Filter.Op.IN, ID, keysAsStr));
     return search(query);
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
@@ -23,7 +23,7 @@ class PostgresQueryParser {
                                 selection, PostgresUtils.DOCUMENT_COLUMN),
                             selection))
                 .collect(Collectors.joining(",")))
-        .filter(str -> StringUtils.isNotBlank(str))
+        .filter(StringUtils::isNotBlank)
         .orElse("*");
   }
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
@@ -1,14 +1,8 @@
 package org.hypertrace.core.documentstore.postgres;
 
-import static org.hypertrace.core.documentstore.Collection.UNSUPPORTED_QUERY_OPERATION;
-import static org.hypertrace.core.documentstore.postgres.PostgresCollection.CREATED_AT;
-import static org.hypertrace.core.documentstore.postgres.PostgresCollection.ID;
-import static org.hypertrace.core.documentstore.postgres.PostgresCollection.UPDATED_AT;
-
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.documentstore.Filter;
@@ -18,138 +12,32 @@ import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 
 class PostgresQueryParser {
 
-  private static final String QUESTION_MARK = "?";
-  // postgres jsonb uses `->` instead of `.` for json field access
-  private static final String JSON_FIELD_ACCESSOR = "->";
-  // postgres operator to fetch the value of json object as text.
-  private static final String JSON_DATA_ACCESSOR = "->>";
-  private static final Set<String> OUTER_COLUMNS =
-      new HashSet<>() {
-        {
-          add(CREATED_AT);
-          add(ID);
-          add(UPDATED_AT);
-        }
-      };
+  static String parseSelections(List<String> selections) {
+    return Optional.of(
+            selections.stream()
+                .map(
+                    selection ->
+                        String.format(
+                            "%s AS \"%s\"",
+                            PostgresUtils.prepareFieldAccessorExpr(
+                                selection, PostgresUtils.DOCUMENT_COLUMN),
+                            selection))
+                .collect(Collectors.joining(",")))
+        .filter(str -> StringUtils.isNotBlank(str))
+        .orElse("*");
+  }
 
   static String parseFilter(Filter filter, Builder paramsBuilder) {
     if (filter.isComposite()) {
       return parseCompositeFilter(filter, paramsBuilder);
     } else {
-      return parseNonCompositeFilter(filter, paramsBuilder);
+      return PostgresUtils.parseNonCompositeFilter(
+          filter.getFieldName(),
+          PostgresUtils.DOCUMENT_COLUMN,
+          filter.getOp().toString(),
+          filter.getValue(),
+          paramsBuilder);
     }
-  }
-
-  static String parseNonCompositeFilter(Filter filter, Builder paramsBuilder) {
-    Filter.Op op = filter.getOp();
-    Object value = filter.getValue();
-    String fieldName = filter.getFieldName();
-    String fullFieldName =
-        prepareCast(
-            PostgresUtils.prepareFieldDataAccessorExpr(fieldName, PostgresUtils.DOCUMENT_COLUMN),
-            value);
-    StringBuilder filterString = new StringBuilder(fullFieldName);
-    String sqlOperator;
-    Boolean isMultiValued = false;
-    switch (op) {
-      case EQ:
-        sqlOperator = " = ";
-        break;
-      case GT:
-        sqlOperator = " > ";
-        break;
-      case LT:
-        sqlOperator = " < ";
-        break;
-      case GTE:
-        sqlOperator = " >= ";
-        break;
-      case LTE:
-        sqlOperator = " <= ";
-        break;
-      case LIKE:
-        // Case insensitive regex search, Append % at beginning and end of value to do a regex
-        // search
-        sqlOperator = " ILIKE ";
-        value = "%" + value + "%";
-        break;
-      case NOT_IN:
-        // NOTE: Below two points
-        // 1. both NOT_IN and IN filter currently limited to non-array field
-        //    - https://github.com/hypertrace/document-store/issues/32#issuecomment-781411676
-        // 2. To make semantically opposite filter of IN, we need to check for if key is not present
-        //    Ref in context of NEQ -
-        // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520Other
-        //    so, we need - "document->key IS NULL OR document->key->> NOT IN (v1, v2)"
-        StringBuilder notInFilterString =
-            PostgresUtils.prepareFieldAccessorExpr(fieldName, PostgresUtils.DOCUMENT_COLUMN);
-        if (notInFilterString != null && !OUTER_COLUMNS.contains(fieldName)) {
-          filterString = notInFilterString.append(" IS NULL OR ").append(fullFieldName);
-        }
-        sqlOperator = " NOT IN ";
-        isMultiValued = true;
-        value = prepareParameterizedStringForList((List<Object>) value, paramsBuilder);
-        break;
-      case IN:
-        // NOTE: both NOT_IN and IN filter currently limited to non-array field
-        //  - https://github.com/hypertrace/document-store/issues/32#issuecomment-781411676
-        sqlOperator = " IN ";
-        isMultiValued = true;
-        value = prepareParameterizedStringForList((List<Object>) value, paramsBuilder);
-        break;
-      case NOT_EXISTS:
-        sqlOperator = " IS NULL ";
-        value = null;
-        // For fields inside jsonb
-        StringBuilder notExists =
-            PostgresUtils.prepareFieldAccessorExpr(fieldName, PostgresUtils.DOCUMENT_COLUMN);
-        if (notExists != null && !OUTER_COLUMNS.contains(fieldName)) {
-          filterString = notExists;
-        }
-        break;
-      case EXISTS:
-        sqlOperator = " IS NOT NULL ";
-        value = null;
-        // For fields inside jsonb
-        StringBuilder exists =
-            PostgresUtils.prepareFieldAccessorExpr(fieldName, PostgresUtils.DOCUMENT_COLUMN);
-        if (exists != null && !OUTER_COLUMNS.contains(fieldName)) {
-          filterString = exists;
-        }
-        break;
-      case NEQ:
-        sqlOperator = " != ";
-        // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520
-        // The expected behaviour is to get all documents which either satisfy non equality
-        // condition
-        // or the key doesn't exist in them
-        // Semantics for handling if key not exists and if it exists, its value
-        // doesn't equal to the filter for Jsonb document will be done as:
-        // "document->key IS NULL OR document->key->> != value"
-        StringBuilder notEquals =
-            PostgresUtils.prepareFieldAccessorExpr(fieldName, PostgresUtils.DOCUMENT_COLUMN);
-        // For fields inside jsonb
-        if (notEquals != null && !OUTER_COLUMNS.contains(fieldName)) {
-          filterString = notEquals.append(" IS NULL OR ").append(fullFieldName);
-        }
-        break;
-      case CONTAINS:
-        // TODO: Matches condition inside an array of documents
-      default:
-        throw new UnsupportedOperationException(UNSUPPORTED_QUERY_OPERATION);
-    }
-
-    filterString.append(sqlOperator);
-    if (value != null) {
-      if (isMultiValued) {
-        filterString.append(value);
-      } else {
-        filterString.append(QUESTION_MARK);
-        paramsBuilder.addObjectParam(value);
-      }
-    }
-    String filters = filterString.toString();
-    return filters;
   }
 
   static String parseCompositeFilter(Filter filter, Builder paramsBuilder) {
@@ -191,41 +79,5 @@ class PostgresQueryParser {
                     + (orderBy.isAsc() ? "ASC" : "DESC"))
         .filter(str -> !StringUtils.isEmpty(str))
         .collect(Collectors.joining(" , "));
-  }
-
-  private static String prepareParameterizedStringForList(
-      List<Object> values, Params.Builder paramsBuilder) {
-    String collect =
-        values.stream()
-            .map(
-                val -> {
-                  paramsBuilder.addObjectParam(val);
-                  return QUESTION_MARK;
-                })
-            .collect(Collectors.joining(", "));
-    return "(" + collect + ")";
-  }
-
-  private static String prepareCast(String field, Object value) {
-    String fmt = "CAST (%s AS %s)";
-
-    // handle the case if the value type is collection for filter operator - `IN`
-    // Currently, for `IN` operator, we are considering List collection, and it is fair
-    // assumption that all its value of the same types. Based on that and for consistency
-    // we will use CAST ( <field name> as <type> ) for all non string operator.
-    // Ref : https://github.com/hypertrace/document-store/pull/30#discussion_r571782575
-
-    if (value instanceof List<?> && ((List<Object>) value).size() > 0) {
-      List<Object> listValue = (List<Object>) value;
-      value = listValue.get(0);
-    }
-
-    if (value instanceof Number) {
-      return String.format(fmt, field, "NUMERIC");
-    } else if (value instanceof Boolean) {
-      return String.format(fmt, field, "BOOLEAN");
-    } else /* default is string */ {
-      return field;
-    }
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -47,10 +47,8 @@ public class PostgresUtils {
       }
       return filterString;
     }
-    // Field accessor is only applicable to jsonb fields, return null otherwise
-    LOGGER.warn(
-        "Returning null string for field name {} and column name {}", fieldName, columnName);
-    return null;
+    // There is no need of field accessor in case of outer column.
+    return new StringBuilder(fieldName);
   }
 
   /**
@@ -187,7 +185,7 @@ public class PostgresUtils {
         // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520Other
         //    so, we need - "document->key IS NULL OR document->key->> NOT IN (v1, v2)"
         StringBuilder notInFilterString = prepareFieldAccessorExpr(fieldName, columnName);
-        if (notInFilterString != null) {
+        if (notInFilterString != null && !OUTER_COLUMNS.contains(fieldName)) {
           filterString = notInFilterString.append(" IS NULL OR ").append(fullFieldName);
         }
         sqlOperator = " NOT IN ";
@@ -206,7 +204,7 @@ public class PostgresUtils {
         value = null;
         // For fields inside jsonb
         StringBuilder notExists = prepareFieldAccessorExpr(fieldName, columnName);
-        if (notExists != null) {
+        if (notExists != null && !OUTER_COLUMNS.contains(fieldName)) {
           filterString = notExists;
         }
         break;
@@ -215,7 +213,7 @@ public class PostgresUtils {
         value = null;
         // For fields inside jsonb
         StringBuilder exists = prepareFieldAccessorExpr(fieldName, columnName);
-        if (exists != null) {
+        if (exists != null && !OUTER_COLUMNS.contains(fieldName)) {
           filterString = exists;
         }
         break;
@@ -230,7 +228,7 @@ public class PostgresUtils {
         // "document->key IS NULL OR document->key->> != value"
         StringBuilder notEquals = prepareFieldAccessorExpr(fieldName, columnName);
         // For fields inside jsonb
-        if (notEquals != null) {
+        if (notEquals != null && !OUTER_COLUMNS.contains(fieldName)) {
           filterString = notEquals.append(" IS NULL OR ").append(fullFieldName);
         }
         break;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -22,6 +22,7 @@ public class PostgresUtils {
   private static final String JSON_DATA_ACCESSOR = "->>";
   private static final String DOT_STR = "_dot_";
   private static final String DOT = ".";
+  public static final String ID_COLUMN = ID;
 
   public static final Set<String> OUTER_COLUMNS =
       new TreeSet<>(List.of(ID, CREATED_AT, UPDATED_AT));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -22,7 +22,6 @@ public class PostgresUtils {
   private static final String JSON_DATA_ACCESSOR = "->>";
   private static final String DOT_STR = "_dot_";
   private static final String DOT = ".";
-  public static final String ID_COLUMN = ID;
 
   public static final Set<String> OUTER_COLUMNS =
       new TreeSet<>(List.of(ID, CREATED_AT, UPDATED_AT));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -15,11 +15,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PostgresUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresUtils.class);
   private static final String QUESTION_MARK = "?";
   private static final String JSON_FIELD_ACCESSOR = "->";
   private static final String JSON_DATA_ACCESSOR = "->>";

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
@@ -296,6 +296,15 @@ class PostgresQueryParserTest {
         PostgresQueryParser.parseOrderBys(orderBys));
   }
 
+  @Test
+  void testSelectionClause() {
+    List<String> selections =
+        List.of("id", "identifyingAttributes", "tenantId", "attributes", "type");
+    Assertions.assertEquals(
+        "id AS \"id\",document->'identifyingAttributes' AS \"identifyingAttributes\",document->'tenantId' AS \"tenantId\",document->'attributes' AS \"attributes\",document->'type' AS \"type\"",
+        PostgresQueryParser.parseSelections(selections));
+  }
+
   private Params.Builder initParams() {
     return Params.newBuilder();
   }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
 import org.hypertrace.core.documentstore.OrderBy;
+import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -19,49 +20,97 @@ class PostgresQueryParserTest {
   void testParseNonCompositeFilter() {
     {
       Filter filter = new Filter(Filter.Op.EQ, ID, "val1");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals(ID + " = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NEQ, ID, "val1");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals(ID + " != ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GT, ID, 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) > ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GTE, ID, 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) >= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LT, ID, 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) < ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LTE, ID, 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals("CAST (" + ID + " AS NUMERIC) <= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LIKE, ID, "abc");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals(ID + " ILIKE ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.IN, ID, List.of("abc", "xyz"));
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query =
+          PostgresUtils.parseNonCompositeFilter(
+              filter.getFieldName(),
+              PostgresUtils.DOCUMENT_COLUMN,
+              filter.getOp().toString(),
+              filter.getValue(),
+              initParams());
       Assertions.assertEquals(ID + " IN (?, ?)", query);
     }
   }
@@ -70,74 +119,74 @@ class PostgresQueryParserTest {
   void testParseNonCompositeFilterForJsonField() {
     {
       Filter filter = new Filter(Filter.Op.EQ, "key1", "val1");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NEQ, "key1", "val1");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL OR document->>'key1' != ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GT, "key1", 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) > ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.GTE, "key1", 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) >= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LT, "key1", 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) < ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LTE, "key1", 5);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("CAST (document->>'key1' AS NUMERIC) <= ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.LIKE, "key1", "abc");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' ILIKE ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.IN, "key1", List.of("abc", "xyz"));
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->>'key1' IN (?, ?)", query);
     }
 
     {
       Filter filter = new Filter(Op.NOT_IN, "key1", List.of("abc", "xyz"));
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL OR document->>'key1' NOT IN (?, ?)", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.EQ, DOCUMENT_ID, "k1:k2");
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->>'_id' = ?", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.EXISTS, "key1.key2", null);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       System.err.println(query);
       Assertions.assertEquals("document->'key1'->'key2' IS NOT NULL ", query);
     }
 
     {
       Filter filter = new Filter(Filter.Op.NOT_EXISTS, "key1", null);
-      String query = PostgresQueryParser.parseNonCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("document->'key1' IS NULL ", query);
     }
   }
@@ -151,7 +200,7 @@ class PostgresQueryParserTest {
       Exception exception =
           assertThrows(
               UnsupportedOperationException.class,
-              () -> PostgresQueryParser.parseNonCompositeFilter(filter, initParams()));
+              () -> PostgresQueryParser.parseFilter(filter, initParams()));
       String actualMessage = exception.getMessage();
       Assertions.assertTrue(actualMessage.contains(expected));
     }
@@ -174,7 +223,7 @@ class PostgresQueryParserTest {
     {
       Filter filter =
           new Filter(Filter.Op.EQ, ID, "val1").and(new Filter(Filter.Op.EQ, CREATED_AT, "val2"));
-      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals(String.format("(%s = ?) AND (%s = ?)", ID, CREATED_AT), query);
     }
 
@@ -182,7 +231,7 @@ class PostgresQueryParserTest {
       Filter filter =
           new Filter(Filter.Op.EQ, ID, "val1").or(new Filter(Filter.Op.EQ, CREATED_AT, "val2"));
 
-      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals(String.format("(%s = ?) OR (%s = ?)", ID, CREATED_AT), query);
     }
   }
@@ -192,7 +241,7 @@ class PostgresQueryParserTest {
     {
       Filter filter =
           new Filter(Filter.Op.EQ, "key1", "val1").and(new Filter(Filter.Op.EQ, "key2", "val2"));
-      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("(document->>'key1' = ?) AND (document->>'key2' = ?)", query);
     }
 
@@ -200,7 +249,7 @@ class PostgresQueryParserTest {
       Filter filter =
           new Filter(Filter.Op.EQ, "key1", "val1").or(new Filter(Filter.Op.EQ, "key2", "val2"));
 
-      String query = PostgresQueryParser.parseCompositeFilter(filter, initParams());
+      String query = PostgresQueryParser.parseFilter(filter, initParams());
       Assertions.assertEquals("(document->>'key1' = ?) OR (document->>'key2' = ?)", query);
     }
   }


### PR DESCRIPTION
Ref : https://github.com/hypertrace/document-store/issues/117

As part of this PR:
- add support for selection clause of order Query API
- support fetching values from the outer column in Postgres
- cleaned up the duplicate code

Tested:
- locally verified, existing tests are working fine
- added unit + integration test for selection clause
- tested with a few additional queries directly

Example:

Doctore Query:
```
Query{selections=[entityId, entityType], filter=_id-EQ-default:testKey1, orderBys=[], offset=null, limit=null}
```

Translated Query:
```
SELECT document->'entityId' AS "entityId",document->'entityType' AS "entityType" 
FROM myTest 
WHERE document->>'_id' = 'default:testKey1'
```
