### PR TITLE
Update Postgres Filter Type Expression Parser to make it extendible to non-identifier type LHS

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParser.java
@@ -31,7 +31,7 @@ class PostgresQueryParser {
     if (filter.isComposite()) {
       return parseCompositeFilter(filter, paramsBuilder);
     } else {
-      return PostgresUtils.parseNonCompositeFilter(
+      return PostgresUtils.parseNonCompositeFilterWithCasting(
           filter.getFieldName(),
           PostgresUtils.DOCUMENT_COLUMN,
           filter.getOp().toString(),

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
@@ -52,17 +52,18 @@ public class PostgresFilterTypeExpressionVisitor implements FilterTypeExpression
     PostgresSelectTypeExpressionVisitor lhsVisitor =
         new PostgresDataAccessorIdentifierExpressionVisitor(postgresQueryParser, getType(value));
 
-    String lhsExpression = lhs.accept(lhsVisitor);
+    final String fieldName = lhs.accept(identifierVisitor);
+    final String lhsExpression = lhs.accept(lhsVisitor);
 
     FieldToPgColumn fieldToPgColumn =
-        postgresQueryParser.getToPgColumnTransformer().transform(lhsExpression);
+        postgresQueryParser.getToPgColumnTransformer().transform(fieldName);
 
     if (fieldToPgColumn.getTransformedField() == null)
       throw new UnsupportedOperationException("jsonb types in where clause is not yet supported");
 
     return PostgresUtils.parseNonCompositeFilter(
-        lhs.accept(identifierVisitor),
         fieldToPgColumn.getTransformedField(),
+        lhsExpression,
         fieldToPgColumn.getPgColumn(),
         operator.toString(),
         value,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFilterTypeExpressionVisitor.java
@@ -53,7 +53,7 @@ public class PostgresFilterTypeExpressionVisitor implements FilterTypeExpression
         new PostgresDataAccessorIdentifierExpressionVisitor(postgresQueryParser, getType(value));
 
     final String fieldName = lhs.accept(identifierVisitor);
-    final String lhsExpression = lhs.accept(lhsVisitor);
+    final String parsedLhsExpression = lhs.accept(lhsVisitor);
 
     FieldToPgColumn fieldToPgColumn =
         postgresQueryParser.getToPgColumnTransformer().transform(fieldName);
@@ -63,7 +63,7 @@ public class PostgresFilterTypeExpressionVisitor implements FilterTypeExpression
 
     return PostgresUtils.parseNonCompositeFilter(
         fieldToPgColumn.getTransformedField(),
-        lhsExpression,
+        parsedLhsExpression,
         fieldToPgColumn.getPgColumn(),
         operator.toString(),
         value,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -151,6 +151,7 @@ public class PostgresUtils {
     return parseNonCompositeFilter(fieldName, fullFieldName, columnName, op, value, paramsBuilder);
   }
 
+  @SuppressWarnings("unchecked")
   public static String parseNonCompositeFilter(
       String fieldName,
       String fullFieldName,
@@ -160,7 +161,7 @@ public class PostgresUtils {
       Builder paramsBuilder) {
     StringBuilder filterString = new StringBuilder(fullFieldName);
     String sqlOperator;
-    Boolean isMultiValued = false;
+    boolean isMultiValued = false;
     switch (op) {
       case "EQ":
         sqlOperator = " = ";
@@ -192,7 +193,7 @@ public class PostgresUtils {
         // https://github.com/hypertrace/document-store/pull/20#discussion_r547101520Other
         //    so, we need - "document->key IS NULL OR document->key->> NOT IN (v1, v2)"
         StringBuilder notInFilterString = prepareFieldAccessorExpr(fieldName, columnName);
-        if (notInFilterString != null && !OUTER_COLUMNS.contains(fieldName)) {
+        if (!OUTER_COLUMNS.contains(fieldName)) {
           filterString = notInFilterString.append(" IS NULL OR ").append(fullFieldName);
         }
         sqlOperator = " NOT IN ";
@@ -211,7 +212,7 @@ public class PostgresUtils {
         value = null;
         // For fields inside jsonb
         StringBuilder notExists = prepareFieldAccessorExpr(fieldName, columnName);
-        if (notExists != null && !OUTER_COLUMNS.contains(fieldName)) {
+        if (!OUTER_COLUMNS.contains(fieldName)) {
           filterString = notExists;
         }
         break;
@@ -220,7 +221,7 @@ public class PostgresUtils {
         value = null;
         // For fields inside jsonb
         StringBuilder exists = prepareFieldAccessorExpr(fieldName, columnName);
-        if (exists != null && !OUTER_COLUMNS.contains(fieldName)) {
+        if (!OUTER_COLUMNS.contains(fieldName)) {
           filterString = exists;
         }
         break;
@@ -235,7 +236,7 @@ public class PostgresUtils {
         // "document->key IS NULL OR document->key->> != value"
         StringBuilder notEquals = prepareFieldAccessorExpr(fieldName, columnName);
         // For fields inside jsonb
-        if (notEquals != null && !OUTER_COLUMNS.contains(fieldName)) {
+        if (!OUTER_COLUMNS.contains(fieldName)) {
           filterString = notEquals.append(" IS NULL OR ").append(fullFieldName);
         }
         break;
@@ -254,8 +255,7 @@ public class PostgresUtils {
         paramsBuilder.addObjectParam(value);
       }
     }
-    String filters = filterString.toString();
-    return filters;
+    return filterString.toString();
   }
 
   /**

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -145,9 +145,19 @@ public class PostgresUtils {
     return "(" + collect + ")";
   }
 
-  public static String parseNonCompositeFilter(
+  public static String parseNonCompositeFilterWithCasting(
       String fieldName, String columnName, String op, Object value, Builder paramsBuilder) {
     String fullFieldName = prepareCast(prepareFieldDataAccessorExpr(fieldName, columnName), value);
+    return parseNonCompositeFilter(fieldName, fullFieldName, columnName, op, value, paramsBuilder);
+  }
+
+  public static String parseNonCompositeFilter(
+      String fieldName,
+      String fullFieldName,
+      String columnName,
+      String op,
+      Object value,
+      Builder paramsBuilder) {
     StringBuilder filterString = new StringBuilder(fullFieldName);
     String sqlOperator;
     Boolean isMultiValued = false;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -147,19 +147,21 @@ public class PostgresUtils {
 
   public static String parseNonCompositeFilterWithCasting(
       String fieldName, String columnName, String op, Object value, Builder paramsBuilder) {
-    String fullFieldName = prepareCast(prepareFieldDataAccessorExpr(fieldName, columnName), value);
-    return parseNonCompositeFilter(fieldName, fullFieldName, columnName, op, value, paramsBuilder);
+    String parsedExpression =
+        prepareCast(prepareFieldDataAccessorExpr(fieldName, columnName), value);
+    return parseNonCompositeFilter(
+        fieldName, parsedExpression, columnName, op, value, paramsBuilder);
   }
 
   @SuppressWarnings("unchecked")
   public static String parseNonCompositeFilter(
       String fieldName,
-      String fullFieldName,
+      String parsedExpression,
       String columnName,
       String op,
       Object value,
       Builder paramsBuilder) {
-    StringBuilder filterString = new StringBuilder(fullFieldName);
+    StringBuilder filterString = new StringBuilder(parsedExpression);
     String sqlOperator;
     boolean isMultiValued = false;
     switch (op) {
@@ -194,7 +196,7 @@ public class PostgresUtils {
         //    so, we need - "document->key IS NULL OR document->key->> NOT IN (v1, v2)"
         StringBuilder notInFilterString = prepareFieldAccessorExpr(fieldName, columnName);
         if (!OUTER_COLUMNS.contains(fieldName)) {
-          filterString = notInFilterString.append(" IS NULL OR ").append(fullFieldName);
+          filterString = notInFilterString.append(" IS NULL OR ").append(parsedExpression);
         }
         sqlOperator = " NOT IN ";
         isMultiValued = true;
@@ -237,7 +239,7 @@ public class PostgresUtils {
         StringBuilder notEquals = prepareFieldAccessorExpr(fieldName, columnName);
         // For fields inside jsonb
         if (!OUTER_COLUMNS.contains(fieldName)) {
-          filterString = notEquals.append(" IS NULL OR ").append(fullFieldName);
+          filterString = notEquals.append(" IS NULL OR ").append(parsedExpression);
         }
         break;
       case "CONTAINS":

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresQueryParserTest.java
@@ -21,7 +21,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.EQ, ID, "val1");
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -33,7 +33,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.NEQ, ID, "val1");
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -45,7 +45,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.GT, ID, 5);
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -57,7 +57,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.GTE, ID, 5);
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -69,7 +69,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.LT, ID, 5);
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -81,7 +81,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.LTE, ID, 5);
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -93,7 +93,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.LIKE, ID, "abc");
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),
@@ -105,7 +105,7 @@ class PostgresQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.IN, ID, List.of("abc", "xyz"));
       String query =
-          PostgresUtils.parseNonCompositeFilter(
+          PostgresUtils.parseNonCompositeFilterWithCasting(
               filter.getFieldName(),
               PostgresUtils.DOCUMENT_COLUMN,
               filter.getOp().toString(),


### PR DESCRIPTION
## Description
Currently, filters only support identifier LHS and constant RHS. We may want to extend it to support functional expression on the LHS. This PR is refactoring the existing code so that the Postgres filter type expression parser could be extended later to support functional expressions.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
All the existing unit and integration tests are passing.
No new test case is required because, it is just refactoring.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
