### PR TITLE
fix: handle group_by identifier more generically

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -745,7 +745,8 @@ public class DocStoreQueryV1Test {
 
   @ParameterizedTest
   @MethodSource("databaseContextBoth")
-  void testQueryQ1DistinctCountAggregationWithMatchingSelectionAndGroupBy(String dataStoreName) throws IOException {
+  void testQueryQ1DistinctCountAggregationWithMatchingSelectionAndGroupBy(String dataStoreName)
+      throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);
     org.hypertrace.core.documentstore.query.Query query =
@@ -755,12 +756,14 @@ public class DocStoreQueryV1Test {
                 "qty_count")
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
-            .setFilter(RelationalExpression.of(IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
+            .setFilter(
+                RelationalExpression.of(
+                    IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
             .addAggregation(IdentifierExpression.of("item"))
             .build();
     try (CloseableIterator<Document> resultDocs = collection.aggregate(query)) {
       assertDocsAndSizeEqualWithoutOrder(
-          dataStoreName, resultDocs, 1, "mongo/test_aggr_only_with_fliter_response.json");
+          dataStoreName, resultDocs, 3, "mongo/test_aggr_with_match_selection_and_groupby.json");
     }
   }
 

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -745,6 +745,27 @@ public class DocStoreQueryV1Test {
 
   @ParameterizedTest
   @MethodSource("databaseContextBoth")
+  void testQueryQ1DistinctCountAggregationWithMatchingSelectionAndGroupBy(String dataStoreName) throws IOException {
+    Datastore datastore = datastoreMap.get(dataStoreName);
+    Collection collection = datastore.getCollection(COLLECTION_NAME);
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(
+                AggregateExpression.of(DISTINCT_COUNT, IdentifierExpression.of("quantity")),
+                "qty_count")
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("price"))
+            .setFilter(RelationalExpression.of(IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
+            .addAggregation(IdentifierExpression.of("item"))
+            .build();
+    try (CloseableIterator<Document> resultDocs = collection.aggregate(query)) {
+      assertDocsAndSizeEqualWithoutOrder(
+          dataStoreName, resultDocs, 1, "mongo/test_aggr_only_with_fliter_response.json");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("databaseContextBoth")
   public void testQueryV1ForSimpleWhereClause(String dataStoreName) throws IOException {
     Datastore datastore = datastoreMap.get(dataStoreName);
     Collection collection = datastore.getCollection(COLLECTION_NAME);

--- a/document-store/src/integrationTest/resources/mongo/test_aggr_with_match_selection_and_groupby.json
+++ b/document-store/src/integrationTest/resources/mongo/test_aggr_with_match_selection_and_groupby.json
@@ -1,0 +1,14 @@
+[
+  {
+    "item":"Soap",
+    "qty_count":2
+  },
+  {
+    "item":"Comb",
+    "qty_count":2
+  },
+  {
+    "item":"Shampoo",
+    "qty_count":2
+  }
+]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresSelectionQueryTransformer.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresSelectionQueryTransformer.java
@@ -1,11 +1,14 @@
 package org.hypertrace.core.documentstore.postgres.query.v1.transformer;
 
+import com.google.common.base.Strings;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
 import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.parser.GroupTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.query.Query;
 import org.hypertrace.core.documentstore.query.SelectionSpec;
@@ -29,18 +32,32 @@ import org.hypertrace.core.documentstore.query.transform.TransformedQueryBuilder
  *
  * This is the similar behavior supported in our other document store implementation (e.g Mongo)
  * */
-public class PostgresSelectionQueryTransformer
-    implements QueryTransformer, SelectTypeExpressionVisitor {
+public class PostgresSelectionQueryTransformer implements QueryTransformer {
 
   @Override
   public Query transform(Query query) {
-    // no-op if group by clause exits
-    if (!query.getAggregations().isEmpty()) return query;
+    SelectTypeAggregationExpressionChecker selectTypeAggregationExpressionChecker = new SelectTypeAggregationExpressionChecker();
+    SelectTypeIdentifierExpressionSelector selectTypeIdentifierExpressionSelector = new SelectTypeIdentifierExpressionSelector();
+
+    Boolean hasAggregationFunction = query.getSelections().stream()
+        .filter(selectionSpec -> selectionSpec.getExpression().accept(selectTypeAggregationExpressionChecker))
+        .findAny()
+        .isEmpty();
+
+    if (!hasAggregationFunction) return query;
+
+    // get all identifier of group by clause
+    LocalGroupByExpressionVisitor groupByExpressionVisitor = new LocalGroupByExpressionVisitor();
+    Set<String> groupByExpressions = query.getAggregations().stream()
+        .map(gte -> (String) gte.accept(groupByExpressionVisitor))
+        .filter(s -> !Strings.isNullOrEmpty(s))
+        .collect(Collectors.toUnmodifiableSet());
 
     // check for all selections, remove non-aggregated selections.
     List<SelectionSpec> finalSelectionSpecs =
         query.getSelections().stream()
-            .filter(selectionSpec -> selectionSpec.getExpression().accept(this))
+            .filter(selectionSpec -> (boolean) selectionSpec.getExpression().accept(selectTypeAggregationExpressionChecker)
+                && groupByExpressions.contains((String)selectionSpec.getExpression().accept(selectTypeIdentifierExpressionSelector)))
             .collect(Collectors.toUnmodifiableList());
 
     return finalSelectionSpecs.size() > 0
@@ -48,23 +65,59 @@ public class PostgresSelectionQueryTransformer
         : query;
   }
 
-  @Override
-  public Boolean visit(AggregateExpression expression) {
-    return true;
+  private static class SelectTypeAggregationExpressionChecker implements SelectTypeExpressionVisitor {
+    @Override
+    public Boolean visit(AggregateExpression expression) {
+      return true;
+    }
+
+    @Override
+    public Boolean visit(ConstantExpression expression) {
+      return false;
+    }
+
+    @Override
+    public Boolean visit(FunctionExpression expression) {
+      return false;
+    }
+
+    @Override
+    public Boolean visit(IdentifierExpression expression) {
+      return false;
+    }
   }
 
-  @Override
-  public Boolean visit(ConstantExpression expression) {
-    return false;
+  private static class SelectTypeIdentifierExpressionSelector implements SelectTypeExpressionVisitor {
+    @Override
+    public String visit(AggregateExpression expression) {
+      return null;
+    }
+
+    @Override
+    public String visit(ConstantExpression expression) {
+      return null;
+    }
+
+    @Override
+    public String visit(FunctionExpression expression) {
+      return null;
+    }
+
+    @Override
+    public String visit(IdentifierExpression expression) {
+      return expression.getName();
+    }
   }
 
-  @Override
-  public Boolean visit(FunctionExpression expression) {
-    return false;
-  }
+  private static class LocalGroupByExpressionVisitor implements GroupTypeExpressionVisitor{
+    @Override
+    public String visit(FunctionExpression expression) {
+      return null;
+    }
 
-  @Override
-  public Boolean visit(IdentifierExpression expression) {
-    return false;
+    @Override
+    public String visit(IdentifierExpression expression) {
+      return expression.getName();
+    }
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresSelectionQueryTransformer.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresSelectionQueryTransformer.java
@@ -77,7 +77,7 @@ public class PostgresSelectionQueryTransformer implements QueryTransformer {
       LocalSelectTypeIdentifierExpressionSelector identifierExpressionSelector) {
     return selectionSpec -> {
       SelectTypeExpression expression = selectionSpec.getExpression();
-      return ((boolean) expression.accept(identifierExpressionSelector))
+      return (!(boolean) expression.accept(identifierExpressionSelector))
           || groupByIdentifierExpressions.contains(expression);
     };
   }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -927,7 +927,9 @@ public class PostgresQueryParserTest {
                 "qty_count")
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
-            .setFilter(RelationalExpression.of(IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
+            .setFilter(
+                RelationalExpression.of(
+                    IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
             .addAggregation(IdentifierExpression.of("item"))
             .build();
 
@@ -937,7 +939,7 @@ public class PostgresQueryParserTest {
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
-            + "document->'item' AS item, document->'price' AS price "
+            + "document->'item' AS item "
             + "FROM testCollection WHERE CAST (document->>'price' AS NUMERIC) <= ? "
             + "GROUP BY document->'item'",
         sql);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -917,4 +917,33 @@ public class PostgresQueryParserTest {
     assertEquals(1, params.getObjectParams().size());
     assertEquals(50, params.getObjectParams().get(1));
   }
+
+  @Test
+  void testQueryQ1DistinctCountAggregationWithMatchingSelectionAndGroupBy() {
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(
+                AggregateExpression.of(DISTINCT_COUNT, IdentifierExpression.of("quantity")),
+                "qty_count")
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("price"))
+            .setFilter(RelationalExpression.of(IdentifierExpression.of("price"), LTE, ConstantExpression.of(10)))
+            .addAggregation(IdentifierExpression.of("item"))
+            .build();
+
+    PostgresQueryParser postgresQueryParser =
+        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+    String sql = postgresQueryParser.parse();
+
+    assertEquals(
+        "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
+            + "document->'item' AS item, document->'price' AS price "
+            + "FROM testCollection WHERE CAST (document->>'price' AS NUMERIC) <= ? "
+            + "GROUP BY document->'item'",
+        sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    assertEquals(1, params.getObjectParams().size());
+    assertEquals(10, params.getObjectParams().get(1));
+  }
 }


### PR DESCRIPTION
The previous fix - https://github.com/hypertrace/document-store/pull/124 for the issue https://github.com/hypertrace/document-store/issues/123, was handling a very specific case.

As part of this PR,
- it makes it more generic, and make sure that all the groupby clause `identifier` match with selection clause identifiers.

Testing:
- all existing tests are passing
- added new unit + integration test

**Example of handling same in existing mongo impl:**
Before transformation:
```
SELECT DISTINCT_COUNT(`quantity`) AS qty_count, `item`, `price` FROM <implicit_collection> WHERE `price` <= 10 GROUP BY `item`
```

After transformation:
```
SELECT DISTINCT(`quantity`) AS qty_count, `_id.item` AS item, `price`, LENGTH(`qty_count`) AS qty_count FROM <implicit_collection> WHERE `price` <= 10 GROUP BY `item`
```

Mongo Query:
```
[{"$match": {"price": {"$lte": 10}}}, 
{"$group": {"qty_count": {"$addToSet": "$quantity"}, "_id": {"item": "$item"}}}, 
{"$project": {"item": "$_id.item", "qty_count": {"$size": "$qty_count"}, "price": 1}}]
```

Response:
```
[{"item":"Soap","qty_count":2},{"item":"Comb","qty_count":2},{"item":"Shampoo","qty_count":2}]
```