### PR TITLE
chore: rename DISTINCT aggregation operator as DISTINCT_ARRAY

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -2,7 +2,7 @@ package org.hypertrace.core.documentstore;
 
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.AVG;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_COUNT;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MAX;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MIN;
@@ -516,7 +516,8 @@ public class DocStoreQueryV1Test {
             .addAggregation(IdentifierExpression.of("price"))
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
-            .addSelection(AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")))
+            .addSelection(
+                AggregateExpression.of(DISTINCT_ARRAY, IdentifierExpression.of("quantity")))
             .build();
 
     assertThrows(RuntimeException.class, () -> collection.aggregate(query));
@@ -535,7 +536,8 @@ public class DocStoreQueryV1Test {
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
             .addSelection(
-                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
+                AggregateExpression.of(DISTINCT_ARRAY, IdentifierExpression.of("quantity")),
+                "quantities")
             .setAggregationFilter(
                 RelationalExpression.of(
                     ConstantExpression.of(1),
@@ -563,7 +565,8 @@ public class DocStoreQueryV1Test {
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
             .addSelection(
-                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
+                AggregateExpression.of(DISTINCT_ARRAY, IdentifierExpression.of("quantity")),
+                "quantities")
             .addSelection(
                 FunctionExpression.builder()
                     .operator(LENGTH)

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
@@ -3,7 +3,7 @@ package org.hypertrace.core.documentstore.expression.operators;
 public enum AggregationOperator {
   AVG,
   COUNT,
-  DISTINCT, // This operator generates an array of distinct values
+  DISTINCT_ARRAY, // This operator generates an array of distinct values
   DISTINCT_COUNT,
   SUM,
   MIN,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoAggregateExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoAggregateExpressionParser.java
@@ -3,7 +3,7 @@ package org.hypertrace.core.documentstore.mongo.parser;
 import static java.util.Collections.unmodifiableMap;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.AVG;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MAX;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MIN;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.SUM;
@@ -23,7 +23,7 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
           new EnumMap<>(AggregationOperator.class) {
             {
               put(AVG, "$avg");
-              put(DISTINCT, "$addToSet");
+              put(DISTINCT_ARRAY, "$addToSet");
               put(SUM, "$sum");
               put(MIN, "$min");
               put(MAX, "$max");

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/transformer/MongoSelectionsUpdatingTransformation.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/transformer/MongoSelectionsUpdatingTransformation.java
@@ -1,7 +1,7 @@
 package org.hypertrace.core.documentstore.mongo.query.transformer;
 
 import static java.util.Collections.unmodifiableMap;
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_COUNT;
 import static org.hypertrace.core.documentstore.mongo.MongoCollection.ID_KEY;
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.FIELD_SEPARATOR;
@@ -73,7 +73,7 @@ import org.hypertrace.core.documentstore.query.SelectionSpec;
  */
 final class MongoSelectionsUpdatingTransformation implements SelectTypeExpressionVisitor {
   private static final Function<AggregateExpression, AggregateExpression> DISTINCT_COUNT_HANDLER =
-      expression -> AggregateExpression.of(DISTINCT, expression.getExpression());
+      expression -> AggregateExpression.of(DISTINCT_ARRAY, expression.getExpression());
 
   private static final Map<AggregationOperator, Function<AggregateExpression, AggregateExpression>>
       AGGREGATION_SUBSTITUTE_MAP =

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
@@ -59,7 +59,7 @@ public class PostgresAggregateExpressionVisitor extends PostgresSelectTypeExpres
   private String convertToAggregationFunction(AggregationOperator operator, String value) {
     if (operator.equals(AggregationOperator.DISTINCT_COUNT)) {
       return String.format("COUNT(DISTINCT %s )", value);
-    } else if (operator.equals(AggregationOperator.DISTINCT)) {
+    } else if (operator.equals(AggregationOperator.DISTINCT_ARRAY)) {
       return String.format("ARRAY_AGG(DISTINCT %s)", value);
     }
     return String.format("%s( %s )", operator, value);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -2,7 +2,7 @@ package org.hypertrace.core.documentstore.postgres.query.v1;
 
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.AVG;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_COUNT;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MAX;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MIN;
@@ -355,7 +355,7 @@ public class PostgresQueryParserTest {
                 RelationalExpression.of(
                     IdentifierExpression.of("price"), EQ, ConstantExpression.of(10)))
             .addSelection(
-                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")),
+                AggregateExpression.of(DISTINCT_ARRAY, IdentifierExpression.of("quantity")),
                 "qty_distinct")
             .addSelection(
                 FunctionExpression.builder()
@@ -391,7 +391,8 @@ public class PostgresQueryParserTest {
             .addSelection(IdentifierExpression.of("item"))
             .addSelection(IdentifierExpression.of("price"))
             .addSelection(
-                AggregateExpression.of(DISTINCT, IdentifierExpression.of("quantity")), "quantities")
+                AggregateExpression.of(DISTINCT_ARRAY, IdentifierExpression.of("quantity")),
+                "quantities")
             .addSelection(
                 FunctionExpression.builder()
                     .operator(LENGTH)


### PR DESCRIPTION
## Description
This PR renames DISTINCT aggregation operator to  DISTINCT_ARRAY. 
 
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Updated all the unit tests accordingly and verified that all pass.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
