### PR TITLE
fix: restore DISTINCT operator

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
@@ -3,6 +3,8 @@ package org.hypertrace.core.documentstore.expression.operators;
 public enum AggregationOperator {
   AVG,
   COUNT,
+  @Deprecated
+  DISTINCT,
   DISTINCT_ARRAY, // This operator generates an array of distinct values
   DISTINCT_COUNT,
   SUM,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/operators/AggregationOperator.java
@@ -3,7 +3,8 @@ package org.hypertrace.core.documentstore.expression.operators;
 public enum AggregationOperator {
   AVG,
   COUNT,
-  @Deprecated
+  /** @deprecated Use {@link AggregationOperator#DISTINCT_ARRAY} instead. */
+  @Deprecated(forRemoval = true)
   DISTINCT,
   DISTINCT_ARRAY, // This operator generates an array of distinct values
   DISTINCT_COUNT,

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoAggregateExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/parser/MongoAggregateExpressionParser.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.documentstore.mongo.parser;
 import static java.util.Collections.unmodifiableMap;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.AVG;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MAX;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MIN;
@@ -23,6 +24,7 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
           new EnumMap<>(AggregationOperator.class) {
             {
               put(AVG, "$avg");
+              put(DISTINCT, "$addToSet");
               put(DISTINCT_ARRAY, "$addToSet");
               put(SUM, "$sum");
               put(MIN, "$min");

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresAggregateExpressionVisitor.java
@@ -59,6 +59,8 @@ public class PostgresAggregateExpressionVisitor extends PostgresSelectTypeExpres
   private String convertToAggregationFunction(AggregationOperator operator, String value) {
     if (operator.equals(AggregationOperator.DISTINCT_COUNT)) {
       return String.format("COUNT(DISTINCT %s )", value);
+    } else if (operator.equals(AggregationOperator.DISTINCT)) {
+      return String.format("ARRAY_AGG(DISTINCT %s)", value);
     } else if (operator.equals(AggregationOperator.DISTINCT_ARRAY)) {
       return String.format("ARRAY_AGG(DISTINCT %s)", value);
     }


### PR DESCRIPTION
## Description
Restores DISTINCT operator(and deprecates it).
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
