### PR TITLE
Enhance the functionalities of the 'create' and 'update' methods

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -24,6 +24,7 @@ import static org.hypertrace.core.documentstore.expression.operators.RelationalO
 import static org.hypertrace.core.documentstore.expression.operators.RelationalOperator.NOT_IN;
 import static org.hypertrace.core.documentstore.expression.operators.SortOrder.ASC;
 import static org.hypertrace.core.documentstore.expression.operators.SortOrder.DESC;
+import static org.hypertrace.core.documentstore.model.options.ReturnDocumentType.BEFORE_UPDATE;
 import static org.hypertrace.core.documentstore.utils.Utils.MONGO_STORE;
 import static org.hypertrace.core.documentstore.utils.Utils.POSTGRES_STORE;
 import static org.hypertrace.core.documentstore.utils.Utils.TENANT_ID;
@@ -60,6 +61,7 @@ import org.hypertrace.core.documentstore.expression.impl.KeyExpression;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.impl.UnnestExpression;
+import org.hypertrace.core.documentstore.model.options.UpdateOptions;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
 import org.hypertrace.core.documentstore.mongo.MongoDatastore;
@@ -1439,7 +1441,10 @@ public class DocStoreQueryV1Test {
     final Callable<Optional<Document>> callable =
         () -> {
           MILLISECONDS.sleep(random.nextInt(1000));
-          return collection.update(query, List.of(dateUpdate, quantityUpdate, propsUpdate));
+          return collection.update(
+              query,
+              List.of(dateUpdate, quantityUpdate, propsUpdate),
+              UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build());
         };
 
     final ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -1505,7 +1510,10 @@ public class DocStoreQueryV1Test {
     final Callable<Optional<Document>> callable =
         () -> {
           MILLISECONDS.sleep(random.nextInt(1000));
-          return collection.update(query, List.of(dateUpdate, quantityUpdate, propsUpdate));
+          return collection.update(
+              query,
+              List.of(dateUpdate, quantityUpdate, propsUpdate),
+              UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build());
         };
 
     final ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -1573,7 +1581,10 @@ public class DocStoreQueryV1Test {
     final Callable<Optional<Document>> callable =
         () -> {
           MILLISECONDS.sleep(random.nextInt(1000));
-          return collection.update(query, List.of(dateUpdate));
+          return collection.update(
+              query,
+              List.of(dateUpdate),
+              UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build());
         };
 
     final ExecutorService executor = Executors.newFixedThreadPool(2);

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -1555,10 +1555,10 @@ public class DocStoreQueryV1Test {
                 .addSelection(IdentifierExpression.of("price"))
                 .addSelection(IdentifierExpression.of("quantity"))
                 .addSelection(IdentifierExpression.of("date"))
-                .addSelection(IdentifierExpression.of("props.brand"), "brand")
+                .addSelection(IdentifierExpression.of("props"))
                 .addSort(IdentifierExpression.of("_id"), ASC)
                 .build()),
-        "query/updatable_collection_data_after_atomic_update.json",
+        "query/updatable_collection_data_after_atomic_update_selecting_all_props.json",
         9);
   }
 

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -42,6 +43,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.hypertrace.core.documentstore.Filter.Op;
 import org.hypertrace.core.documentstore.commons.DocStoreConstants;
+import org.hypertrace.core.documentstore.model.exception.DuplicateDocumentException;
 import org.hypertrace.core.documentstore.mongo.MongoDatastore;
 import org.hypertrace.core.documentstore.postgres.PostgresDatastore;
 import org.hypertrace.core.documentstore.utils.CreateUpdateTestThread;
@@ -2145,6 +2147,23 @@ public class DocStoreTest {
     Assertions.assertTrue(documents.size() == 1);
     Map<String, Object> doc = OBJECT_MAPPER.readValue(documents.get(0).toJson(), Map.class);
     Assertions.assertEquals(resultMap.get(SUCCESS).get(0).getTestValue(), (int) doc.get("size"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("databaseContextProvider")
+  public void testCreateWithMultipleValues(final String dataStoreName) throws Exception {
+    final Datastore datastore = datastoreMap.get(dataStoreName);
+    final Collection collection = datastore.getCollection(COLLECTION_NAME);
+    final SingleValueKey documentKey = new SingleValueKey("default", "testKey1");
+
+    @SuppressWarnings("unchecked")
+    final Document document =
+        Utils.createDocument(
+            ImmutablePair.of("id", documentKey.getValue()),
+            ImmutablePair.of("name", String.format("thread-%s", UUID.randomUUID())));
+
+    collection.create(documentKey, document);
+    assertThrows(DuplicateDocumentException.class, () -> collection.create(documentKey, document));
   }
 
   @ParameterizedTest

--- a/document-store/src/integrationTest/resources/query/atomic_update_response_get_new_document.json
+++ b/document-store/src/integrationTest/resources/query/atomic_update_response_get_new_document.json
@@ -1,0 +1,44 @@
+[
+  {
+    "date": "2022-08-09T18:53:17Z",
+    "price": 10,
+    "props": {
+      "new_property": {
+        "deep": {
+          "nested": {
+            "value": {
+              "json": "new_value"
+            }
+          }
+        }
+      },
+      "brand": "Dettol",
+      "size": "M",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd.",
+        "address": {
+          "city": "Mumbai",
+          "pincode": 400004
+        }
+      }
+    },
+    "quantity": 1000
+  },
+  {
+    "date": "2022-08-09T18:53:17Z",
+    "price": 10,
+    "quantity": 1000,
+    "props": {
+      "brand": "Dettol",
+      "new_property": {
+        "deep": {
+          "nested": {
+            "value": {
+              "json": "new_value"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/document-store/src/integrationTest/resources/query/updatable_collection_data_after_atomic_update_selecting_all_props.json
+++ b/document-store/src/integrationTest/resources/query/updatable_collection_data_after_atomic_update_selecting_all_props.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2022-08-09T18:53:17Z",
+    "item": "Soap",
+    "price": 10,
+    "quantity": 1000,
+    "props": {
+      "brand": "Dettol",
+      "size": "M",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd.",
+        "address": {
+          "city": "Mumbai",
+          "pincode": 400004
+        }
+      },
+      "new_property": {
+        "deep": {
+          "nested": {
+            "value": {
+              "json": "new_value"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "date": "2014-03-01T09:00:00Z",
+    "item": "Mirror",
+    "price": 20,
+    "quantity": 1
+  },
+  {
+    "date": "2014-03-15T09:00:00Z",
+    "item": "Shampoo",
+    "price": 5,
+    "quantity": 10,
+    "props": {
+      "brand": "Sunsilk",
+      "size": "L",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd.",
+        "address": {
+          "city": "Mumbai",
+          "pincode": 400004
+        }
+      }
+    }
+  },
+  {
+    "date": "2014-04-04T11:21:39.736Z",
+    "item": "Shampoo",
+    "price": 5,
+    "quantity": 20
+  },
+  {
+    "date": "2014-04-04T21:23:13.331Z",
+    "item": "Soap",
+    "price": 20,
+    "quantity": 5,
+    "props": {
+      "brand": "Lifebuoy",
+      "size": "S",
+      "seller": {
+        "name": "Hans and Co.",
+        "address": {
+          "city": "Kolkata",
+          "pincode": 700007
+        }
+      }
+    }
+  },
+  {
+    "date": "2015-06-04T05:08:13Z",
+    "item": "Comb",
+    "price": 7.5,
+    "quantity": 5
+  },
+  {
+    "date": "2015-09-10T08:43:00Z",
+    "item": "Comb",
+    "price": 7.5,
+    "quantity": 10,
+    "props": {
+      "seller": {
+        "name": "Go Go Plastics",
+        "address": {
+          "city": "Kolkata",
+          "pincode": 700007
+        }
+      }
+    }
+  },
+  {
+    "date": "2022-08-09T18:53:17Z",
+    "item": "Soap",
+    "price": 10,
+    "quantity": 1000,
+    "props": {
+      "brand": "Dettol",
+      "new_property": {
+        "deep": {
+          "nested": {
+            "value": {
+              "json": "new_value"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "item": "Soap",
+    "price": 88,
+    "quantity": 50,
+    "date": "2023-08-09T18:53:17Z"
+  }
+]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/expression/impl/KeyExpression.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/expression/impl/KeyExpression.java
@@ -21,6 +21,17 @@ public class KeyExpression implements FilterTypeExpression {
     return new KeyExpression(key);
   }
 
+  public static KeyExpression from(final String keyString) {
+    Preconditions.checkArgument(keyString != null, "key is null");
+    return new KeyExpression(
+        new Key() {
+          @Override
+          public String toString() {
+            return keyString;
+          }
+        });
+  }
+
   @Override
   public <T> T accept(final FilterTypeExpressionVisitor visitor) {
     return visitor.visit(this);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/exception/DuplicateDocumentException.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/exception/DuplicateDocumentException.java
@@ -1,0 +1,5 @@
+package org.hypertrace.core.documentstore.model.exception;
+
+import java.io.IOException;
+
+public class DuplicateDocumentException extends IOException {}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/options/ReturnDocumentType.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/options/ReturnDocumentType.java
@@ -1,0 +1,6 @@
+package org.hypertrace.core.documentstore.model.options;
+
+public enum ReturnDocumentType {
+  BEFORE_UPDATE,
+  AFTER_UPDATE,
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/options/UpdateOptions.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/options/UpdateOptions.java
@@ -1,0 +1,15 @@
+package org.hypertrace.core.documentstore.model.options;
+
+import static org.hypertrace.core.documentstore.model.options.ReturnDocumentType.AFTER_UPDATE;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class UpdateOptions {
+  public static UpdateOptions DEFAULT_UPDATE_OPTIONS =
+      UpdateOptions.builder().returnDocumentType(AFTER_UPDATE).build();
+
+  ReturnDocumentType returnDocumentType;
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
@@ -5,6 +5,7 @@ import static org.hypertrace.core.documentstore.commons.DocStoreConstants.CREATE
 import static org.hypertrace.core.documentstore.commons.DocStoreConstants.LAST_UPDATED_TIME;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -14,6 +15,7 @@ import lombok.Value;
 @AllArgsConstructor(access = PRIVATE)
 public class SubDocument {
   private static final Set<String> IMPLICIT_PATHS = Set.of(CREATED_TIME, LAST_UPDATED_TIME);
+  private static final Pattern ALLOWED_CHARACTERS = Pattern.compile("^[a-zA-Z_]+(.[a-zA-Z_]+)*$");
 
   String path;
 
@@ -35,6 +37,10 @@ public class SubDocument {
       if (IMPLICIT_PATHS.contains(path)) {
         throw new IllegalArgumentException(
             String.format("%s is maintained implicitly. Please use a different path.", path));
+      }
+
+      if (!ALLOWED_CHARACTERS.matcher(path).matches()) {
+        throw new IllegalArgumentException(String.format("Illegal path: %s", path));
       }
     }
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryBuilder.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryBuilder.java
@@ -1,10 +1,16 @@
 package org.hypertrace.core.documentstore.postgres;
 
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOCUMENT;
+import static org.hypertrace.core.documentstore.postgres.PostgresCollection.DOC_PATH_SEPARATOR;
 import static org.hypertrace.core.documentstore.postgres.PostgresCollection.ID;
+import static org.hypertrace.core.documentstore.postgres.utils.PostgresUtils.formatSubDocPath;
+import static org.hypertrace.core.documentstore.postgres.utils.PostgresUtils.prepareFieldAccessorExpr;
 
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
+import org.hypertrace.core.documentstore.postgres.subdoc.PostgresSubDocumentValueGetter;
 import org.hypertrace.core.documentstore.postgres.subdoc.PostgresSubDocumentValueParser;
 
 @RequiredArgsConstructor
@@ -12,14 +18,38 @@ public class PostgresQueryBuilder {
   private final String collectionName;
   private final PostgresSubDocumentValueParser subDocValueParser =
       new PostgresSubDocumentValueParser();
+  private final PostgresSubDocumentValueGetter subDocValueGetter =
+      new PostgresSubDocumentValueGetter();
 
-  public String getSubDocUpdateQuery(final SubDocumentValue subDocValue) {
+  public String getSubDocUpdateQuery(
+      final SubDocumentUpdate update, final String id, final Params.Builder paramBuilder) {
+    final String[] path = update.getSubDocument().getPath().split(DOC_PATH_SEPARATOR);
+    final String setCommand =
+        getJsonbSetCall(DOCUMENT, path, update.getSubDocumentValue(), paramBuilder);
+    paramBuilder.addObjectParam(id);
+
     return String.format(
-        "UPDATE %s SET %s=jsonb_set(%s, ?::text[], %s) WHERE %s=?",
-        collectionName, DOCUMENT, DOCUMENT, subDocValue.accept(subDocValueParser), ID);
+        "UPDATE %s SET %s=%s WHERE %s=?", collectionName, DOCUMENT, setCommand, ID);
   }
 
-  public String getFindByIdQuery() {
-    return String.format("SELECT * FROM %s WHERE %s=?", collectionName, ID);
+  private String getJsonbSetCall(
+      final String baseField,
+      final String[] path,
+      final SubDocumentValue value,
+      final Params.Builder paramBuilder) {
+    if (path.length == 1) {
+      paramBuilder.addObjectParam(formatSubDocPath(path[0]));
+      paramBuilder.addObjectParam(value.accept(subDocValueGetter));
+      return String.format(
+          "jsonb_set(COALESCE(%s, '{}'), ?::text[], %s)",
+          baseField, value.accept(subDocValueParser));
+    }
+
+    final String[] pathExcludingFirst = Arrays.stream(path).skip(1).toArray(String[]::new);
+    paramBuilder.addObjectParam(formatSubDocPath(path[0]));
+    final String fieldAccess = prepareFieldAccessorExpr(path[0], baseField).toString();
+    final String nestedSetQuery =
+        getJsonbSetCall(fieldAccess, pathExcludingFirst, value, paramBuilder);
+    return String.format("jsonb_set(COALESCE(%s, '{}'), ?::text[], %s)", baseField, nestedSetQuery);
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryBuilder.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryBuilder.java
@@ -18,4 +18,8 @@ public class PostgresQueryBuilder {
         "UPDATE %s SET %s=jsonb_set(%s, ?::text[], %s) WHERE %s=?",
         collectionName, DOCUMENT, DOCUMENT, subDocValue.accept(subDocValueParser), ID);
   }
+
+  public String getFindByIdQuery() {
+    return String.format("SELECT * FROM %s WHERE %s=?", collectionName, ID);
+  }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
@@ -8,9 +8,21 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import lombok.AllArgsConstructor;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.core.documentstore.CloseableIterator;
+import org.hypertrace.core.documentstore.Document;
+import org.hypertrace.core.documentstore.postgres.PostgresCollection.PostgresResultIterator;
+import org.hypertrace.core.documentstore.postgres.PostgresCollection.PostgresResultIteratorWithMetaData;
+import org.hypertrace.core.documentstore.postgres.query.v1.transformer.PostgresQueryTransformer;
+import org.hypertrace.core.documentstore.query.Query;
 
+@Slf4j
+@AllArgsConstructor
 public class PostgresQueryExecutor {
+  private final String collectionName;
+
   public QueryResult execute(final Connection connection, final String query, final Params params)
       throws SQLException {
     final PreparedStatement preparedStatement = connection.prepareStatement(query);
@@ -18,6 +30,42 @@ public class PostgresQueryExecutor {
     final ResultSet resultSet = preparedStatement.executeQuery();
 
     return new QueryResult(preparedStatement, resultSet);
+  }
+
+  public CloseableIterator<Document> execute(final Connection connection, final Query query) {
+    final org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser queryParser =
+        new org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser(
+            collectionName, transformAndLog(query));
+    final String sqlQuery = queryParser.parse();
+    try {
+      final PreparedStatement preparedStatement =
+          buildPreparedStatement(sqlQuery, queryParser.getParamsBuilder().build(), connection);
+      log.debug("Executing executeQueryV1 sqlQuery:{}", preparedStatement.toString());
+      final ResultSet resultSet = preparedStatement.executeQuery();
+      return query.getSelections().size() > 0
+          ? new PostgresResultIteratorWithMetaData(resultSet)
+          : new PostgresResultIterator(resultSet);
+    } catch (SQLException e) {
+      log.error(
+          "SQLException querying documents. original query: " + query + ", sql query:" + sqlQuery,
+          e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  public PreparedStatement buildPreparedStatement(
+      String sqlQuery, Params params, Connection connection) throws SQLException, RuntimeException {
+    PreparedStatement preparedStatement = connection.prepareStatement(sqlQuery);
+    enrichPreparedStatementWithParams(preparedStatement, params);
+    return preparedStatement;
+  }
+
+  private static org.hypertrace.core.documentstore.query.Query transformAndLog(
+      org.hypertrace.core.documentstore.query.Query query) {
+    log.debug("Original query before transformation: {}", query);
+    query = PostgresQueryTransformer.transform(query);
+    log.debug("Query after transformation: {}", query);
+    return query;
   }
 
   @Value

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
@@ -2,14 +2,11 @@ package org.hypertrace.core.documentstore.postgres;
 
 import static org.hypertrace.core.documentstore.postgres.utils.PostgresUtils.enrichPreparedStatementWithParams;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import lombok.AllArgsConstructor;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.hypertrace.core.documentstore.CloseableIterator;
 import org.hypertrace.core.documentstore.Document;
@@ -22,15 +19,6 @@ import org.hypertrace.core.documentstore.query.Query;
 @AllArgsConstructor
 public class PostgresQueryExecutor {
   private final String collectionName;
-
-  public QueryResult execute(final Connection connection, final String query, final Params params)
-      throws SQLException {
-    final PreparedStatement preparedStatement = connection.prepareStatement(query);
-    enrichPreparedStatementWithParams(preparedStatement, params);
-    final ResultSet resultSet = preparedStatement.executeQuery();
-
-    return new QueryResult(preparedStatement, resultSet);
-  }
 
   public CloseableIterator<Document> execute(final Connection connection, final Query query) {
     final org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser queryParser =
@@ -66,21 +54,5 @@ public class PostgresQueryExecutor {
     query = PostgresQueryTransformer.transform(query);
     log.debug("Query after transformation: {}", query);
     return query;
-  }
-
-  @Value
-  public static class QueryResult implements Closeable {
-    PreparedStatement preparedStatement;
-    ResultSet resultSet;
-
-    @Override
-    public void close() throws IOException {
-      try {
-        resultSet.close();
-        preparedStatement.close();
-      } catch (final SQLException e) {
-        throw new IOException(e);
-      }
-    }
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
@@ -1,0 +1,38 @@
+package org.hypertrace.core.documentstore.postgres;
+
+import static org.hypertrace.core.documentstore.postgres.utils.PostgresUtils.enrichPreparedStatementWithParams;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.Value;
+
+public class PostgresQueryExecutor {
+  public QueryResult execute(final Connection connection, final String query, final Params params)
+      throws SQLException {
+    final PreparedStatement preparedStatement = connection.prepareStatement(query);
+    enrichPreparedStatementWithParams(preparedStatement, params);
+    final ResultSet resultSet = preparedStatement.executeQuery();
+
+    return new QueryResult(preparedStatement, resultSet);
+  }
+
+  @Value
+  public static class QueryResult implements Closeable {
+    PreparedStatement preparedStatement;
+    ResultSet resultSet;
+
+    @Override
+    public void close() throws IOException {
+      try {
+        resultSet.close();
+        preparedStatement.close();
+      } catch (final SQLException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java
@@ -12,6 +12,8 @@ import static org.hypertrace.core.documentstore.postgres.PostgresCollection.UPDA
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -19,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.JSONDocument;
@@ -26,6 +29,7 @@ import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
 import org.hypertrace.core.documentstore.postgres.model.DocumentAndId;
 
+@Slf4j
 public class PostgresUtils {
   private static final String QUESTION_MARK = "?";
   private static final String JSON_FIELD_ACCESSOR = "->";
@@ -416,5 +420,23 @@ public class PostgresUtils {
     final String id = String.valueOf(requireNonNull(map.remove(IMPLICIT_ID)));
     final Document documentWithoutId = new JSONDocument(new ObjectMapper().writeValueAsString(map));
     return new DocumentAndId(documentWithoutId, id);
+  }
+
+  public static void enrichPreparedStatementWithParams(
+      final PreparedStatement preparedStatement, final Params params) {
+    params
+        .getObjectParams()
+        .forEach(
+            (k, v) -> {
+              try {
+                if (isValidPrimitiveType(v)) {
+                  preparedStatement.setObject(k, v);
+                } else {
+                  throw new UnsupportedOperationException("Un-supported object types in filter");
+                }
+              } catch (SQLException e) {
+                log.error("SQLException setting Param. key: {}, value: {}", k, v);
+              }
+            });
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -38,6 +38,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
+import org.hypertrace.core.documentstore.model.options.UpdateOptions;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
 import org.hypertrace.core.documentstore.query.SortingSpec;
@@ -231,7 +232,10 @@ public class MongoCollectionTest {
         .thenReturn(response);
 
     final Optional<Document> result =
-        mongoCollection.update(query, List.of(dateUpdate, quantityUpdate, propsUpdate));
+        mongoCollection.update(
+            query,
+            List.of(dateUpdate, quantityUpdate, propsUpdate),
+            UpdateOptions.DEFAULT_UPDATE_OPTIONS);
 
     assertTrue(result.isPresent());
     assertJsonEquals(
@@ -250,6 +254,8 @@ public class MongoCollectionTest {
         IOException.class,
         () ->
             mongoCollection.update(
-                org.hypertrace.core.documentstore.query.Query.builder().build(), emptyList()));
+                org.hypertrace.core.documentstore.query.Query.builder().build(),
+                emptyList(),
+                UpdateOptions.DEFAULT_UPDATE_OPTIONS));
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -8,6 +8,7 @@ import static org.hypertrace.core.documentstore.expression.operators.RelationalO
 import static org.hypertrace.core.documentstore.expression.operators.RelationalOperator.LT;
 import static org.hypertrace.core.documentstore.expression.operators.SortOrder.ASC;
 import static org.hypertrace.core.documentstore.expression.operators.SortOrder.DESC;
+import static org.hypertrace.core.documentstore.model.options.ReturnDocumentType.BEFORE_UPDATE;
 import static org.hypertrace.core.documentstore.util.TestUtil.readDocument;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,6 +34,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
+import org.hypertrace.core.documentstore.model.options.UpdateOptions;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
 import org.hypertrace.core.documentstore.query.Query;
@@ -119,7 +121,9 @@ class PostgresCollectionTest {
 
     when(mockClock.millis()).thenReturn(currentTime);
 
-    final Optional<Document> oldDocument = postgresCollection.update(query, updates);
+    final Optional<Document> oldDocument =
+        postgresCollection.update(
+            query, updates, UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build());
 
     assertTrue(oldDocument.isPresent());
     assertEquals(document, oldDocument.get());
@@ -204,7 +208,9 @@ class PostgresCollectionTest {
     when(mockSelectPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(false);
 
-    final Optional<Document> oldDocument = postgresCollection.update(query, updates);
+    final Optional<Document> oldDocument =
+        postgresCollection.update(
+            query, updates, UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build());
 
     assertTrue(oldDocument.isEmpty());
 
@@ -291,7 +297,11 @@ class PostgresCollectionTest {
 
     when(mockUpdatePreparedStatement.executeUpdate()).thenThrow(SQLException.class);
 
-    assertThrows(IOException.class, () -> postgresCollection.update(query, updates));
+    assertThrows(
+        IOException.class,
+        () ->
+            postgresCollection.update(
+                query, updates, UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build()));
 
     verify(mockClient, times(1)).getNewConnection();
     verify(mockConnection, times(1)).setAutoCommit(false);
@@ -352,7 +362,9 @@ class PostgresCollectionTest {
         IOException.class,
         () ->
             postgresCollection.update(
-                org.hypertrace.core.documentstore.query.Query.builder().build(), emptyList()));
+                org.hypertrace.core.documentstore.query.Query.builder().build(),
+                emptyList(),
+                UpdateOptions.builder().returnDocumentType(BEFORE_UPDATE).build()));
   }
 
   private Query buildQueryWithFilterSortAndProjection() {

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -108,14 +108,14 @@ class PostgresCollectionTest {
     final PreparedStatement update2PrepStatement = mock(PreparedStatement.class);
     when(mockConnection.prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], to_jsonb(?)) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], to_jsonb(?)) WHERE id=?",
                 COLLECTION_NAME)))
         .thenReturn(update1PrepStatement, update2PrepStatement, mockUpdatePreparedStatement);
 
     final PreparedStatement update3PrepStatement = mock(PreparedStatement.class);
     when(mockConnection.prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], ?::jsonb) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], ?::jsonb) WHERE id=?",
                 COLLECTION_NAME)))
         .thenReturn(update3PrepStatement);
 
@@ -155,12 +155,12 @@ class PostgresCollectionTest {
     verify(mockConnection, times(3))
         .prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], to_jsonb(?)) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], to_jsonb(?)) WHERE id=?",
                 COLLECTION_NAME));
     verify(mockConnection, times(1))
         .prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], ?::jsonb) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], ?::jsonb) WHERE id=?",
                 COLLECTION_NAME));
 
     verifyUpdate(id, update1PrepStatement, "{date}", "2022-08-09T18:53:17Z");
@@ -282,14 +282,14 @@ class PostgresCollectionTest {
     final PreparedStatement update2PrepStatement = mock(PreparedStatement.class);
     when(mockConnection.prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], to_jsonb(?)) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], to_jsonb(?)) WHERE id=?",
                 COLLECTION_NAME)))
         .thenReturn(update1PrepStatement, update2PrepStatement, mockUpdatePreparedStatement);
 
     final PreparedStatement update3PrepStatement = mock(PreparedStatement.class);
     when(mockConnection.prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], ?::jsonb) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], ?::jsonb) WHERE id=?",
                 COLLECTION_NAME)))
         .thenReturn(update3PrepStatement);
 
@@ -330,12 +330,12 @@ class PostgresCollectionTest {
     verify(mockConnection, times(3))
         .prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], to_jsonb(?)) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], to_jsonb(?)) WHERE id=?",
                 COLLECTION_NAME));
     verify(mockConnection, times(1))
         .prepareStatement(
             String.format(
-                "UPDATE %s SET document=jsonb_set(document, ?::text[], ?::jsonb) WHERE id=?",
+                "UPDATE %s SET document=jsonb_set(COALESCE(document, '{}'), ?::text[], ?::jsonb) WHERE id=?",
                 COLLECTION_NAME));
 
     verifyUpdate(id, update1PrepStatement, "{date}", "2022-08-09T18:53:17Z");
@@ -429,9 +429,9 @@ class PostgresCollectionTest {
       final String subDocPath,
       final T value)
       throws SQLException {
-    verify(preparedStatement, times(1)).setString(1, subDocPath);
+    verify(preparedStatement, times(1)).setObject(1, subDocPath);
     verify(preparedStatement, times(1)).setObject(2, value);
-    verify(preparedStatement, times(1)).setString(3, id);
+    verify(preparedStatement, times(1)).setObject(3, id);
     verify(preparedStatement, times(1)).executeUpdate();
   }
 }


### PR DESCRIPTION
1. Previously the 'create' method was throwing a general IOException irrespective of whether the failure was due to a duplicate key or other reasons. This PR fixes to throw a DuplicateDocumentException in case the failure is due to unique key violations
2. This PR also introduces update options to return old or new document for update
3. Also, this PR fixes a bug in updating nested fields for Postgres


### Testing
Added the necessary unit and integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
