### PR TITLE
Upgarded jackson-databind to eradicate CVE-2022-42004

### DIFF
--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   implementation("org.apache.commons:commons-collections4:4.4")
   implementation("org.postgresql:postgresql:42.4.1")
   implementation("org.mongodb:mongodb-driver-sync:4.6.0")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
   implementation("org.slf4j:slf4j-api:1.7.36")
   implementation("com.google.guava:guava-annotations:r03")
   implementation("org.apache.commons:commons-lang3:3.12.0")


### PR DESCRIPTION
Upgarded jackson-databind to eradicate CVE-2022-42004 
ref : https://nvd.nist.gov/vuln/detail/CVE-2022-42004