### PR TITLE
feat: adds support for pre-processing unnest filter for compatibility

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -1249,6 +1249,7 @@ public class DocStoreQueryV1Test {
                             EQ,
                             ConstantExpression.of("mumbai")))
                     .build())
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales.medium"), true))
             .setFilter(
                 LogicalExpression.builder()
                     .operator(AND)

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -1266,7 +1266,7 @@ public class DocStoreQueryV1Test {
 
     Iterator<Document> iterator = collection.aggregate(query);
     assertDocsAndSizeEqual(
-        dataStoreName, iterator, "query/unwind_preserve_with_regular_filter_first_level.json", 1);
+        dataStoreName, iterator, "query/unwind_preserve_with_regular_filter_first_level.json", 3);
   }
 
   @ParameterizedTest

--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -1188,6 +1188,88 @@ public class DocStoreQueryV1Test {
 
   @ParameterizedTest
   @MethodSource("databaseContextBoth")
+  public void testUnnestWithRegularFilterAndNullAndEmptyPreservedAtSecondLevel(String dataStoreName)
+      throws IOException {
+    Collection collection = getCollection(dataStoreName);
+
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("quantity"))
+            .addSelection(IdentifierExpression.of("sales.city"))
+            .addSelection(IdentifierExpression.of("sales.medium.type"))
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales"), true))
+            .addFromClause(
+                UnnestExpression.builder()
+                    .identifierExpression(IdentifierExpression.of("sales.medium"))
+                    .preserveNullAndEmptyArrays(true)
+                    .filterTypeExpression(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .setFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .build();
+
+    Iterator<Document> iterator = collection.aggregate(query);
+    assertDocsAndSizeEqual(
+        dataStoreName, iterator, "query/unwind_preserve_with_regular_filter_second_level.json", 2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("databaseContextBoth")
+  public void testUnnestWithRegularFilterAndNullAndEmptyPreservedAtFirstLevel(String dataStoreName)
+      throws IOException {
+    Collection collection = getCollection(dataStoreName);
+
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("quantity"))
+            .addSelection(IdentifierExpression.of("sales.city"))
+            .addFromClause(
+                UnnestExpression.builder()
+                    .identifierExpression(IdentifierExpression.of("sales"))
+                    .preserveNullAndEmptyArrays(true)
+                    .filterTypeExpression(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.city"),
+                            EQ,
+                            ConstantExpression.of("mumbai")))
+                    .build())
+            .setFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.city"),
+                            EQ,
+                            ConstantExpression.of("mumbai")))
+                    .build())
+            .build();
+
+    Iterator<Document> iterator = collection.aggregate(query);
+    assertDocsAndSizeEqual(
+        dataStoreName, iterator, "query/unwind_preserve_with_regular_filter_first_level.json", 1);
+  }
+
+  @ParameterizedTest
+  @MethodSource("databaseContextBoth")
   public void testQueryV1DistinctCountWithSortingSpecs(String dataStoreName) throws IOException {
     Collection collection = getCollection(dataStoreName);
 

--- a/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_first_level.json
+++ b/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_first_level.json
@@ -1,0 +1,9 @@
+[
+  {
+    "item":"Shampoo",
+    "quantity":10,
+    "sales":{
+      "city":"mumbai"
+    }
+  }
+]

--- a/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_first_level.json
+++ b/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_first_level.json
@@ -5,5 +5,19 @@
     "sales":{
       "city":"mumbai"
     }
+  },
+  {
+    "item":"Shampoo",
+    "quantity":10,
+    "sales":{
+      "city":"mumbai"
+    }
+  },
+  {
+    "item":"Shampoo",
+    "quantity":10,
+    "sales":{
+      "city":"mumbai"
+    }
   }
 ]

--- a/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_second_level.json
+++ b/document-store/src/integrationTest/resources/query/unwind_preserve_with_regular_filter_second_level.json
@@ -1,0 +1,22 @@
+[
+  {
+    "item":"Shampoo",
+    "quantity":10,
+    "sales":{
+      "city":"delhi",
+      "medium":{
+        "type":"retail"
+      }
+    }
+  },
+  {
+    "item":"Shampoo",
+    "quantity":10,
+    "sales":{
+      "city":"mumbai",
+      "medium":{
+        "type":"retail"
+      }
+    }
+  }
+]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresQueryTransformer.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresQueryTransformer.java
@@ -11,6 +11,7 @@ public class PostgresQueryTransformer {
   private static final List<QueryTransformer> TRANSFORMERS =
       new ImmutableList.Builder<QueryTransformer>()
           .add(new PostgresSelectionQueryTransformer())
+          .add(new PostgresUnnestQueryTransformer())
           .build();
 
   public static Query transform(final Query query) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresUnnestQueryTransformer.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/transformer/PostgresUnnestQueryTransformer.java
@@ -1,0 +1,260 @@
+package org.hypertrace.core.documentstore.postgres.query.v1.transformer;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
+import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
+import org.hypertrace.core.documentstore.expression.impl.FunctionExpression;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.expression.impl.KeyExpression;
+import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
+import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
+import org.hypertrace.core.documentstore.expression.impl.UnnestExpression;
+import org.hypertrace.core.documentstore.expression.operators.LogicalOperator;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
+import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
+import org.hypertrace.core.documentstore.parser.FilterTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.parser.FromTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
+import org.hypertrace.core.documentstore.query.Query;
+import org.hypertrace.core.documentstore.query.transform.QueryTransformer;
+import org.hypertrace.core.documentstore.query.transform.TransformedQueryBuilder;
+
+/**
+ * Accessing an item of a JSON array w/o index expression results in no match in Postgres.
+ *
+ * <p>As an example, { "item":"Soap", "sales":[ { "city":"delhi" } ] }. If we try to access
+ * `sales.city` it will return null as there is no key at `sales`.
+ *
+ * <p>However, as mongo supports -EQ- operator on array field that behaves as contains internally,
+ * `sales.city-EQ-delhi` is a valid filter expression. Ideally, the client should have expressed
+ * contains as `sales-CONTAINS-{"city":"delhi"}`.
+ *
+ * <p>To support compatibility, this pre-processor moves any applied filter on the array field to
+ * unnest expression filter.
+ */
+public class PostgresUnnestQueryTransformer implements QueryTransformer {
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Query transform(Query query) {
+    // Don't do any thing if there is no unnest expression
+    if (query.getFromTypeExpressions().size() <= 0) {
+      return query;
+    }
+
+    // Prepare an AND tree of filters. If, any OR filter, the full sub-tree needs to move.
+    AndFiltersCollector andFiltersCollector = new AndFiltersCollector();
+    List<FilterTypeExpression> andFilters =
+        query
+            .getFilter()
+            .map(
+                filterTypeExpression ->
+                    filterTypeExpression.<List<FilterTypeExpression>>accept(andFiltersCollector))
+            .orElse(List.of());
+
+    // check if any filter matches with unnest expression
+    // if matches, move the matched one to unnest filter and remove it from main filter list
+    List<FilterTypeExpression> finalAndFilters = new ArrayList<>();
+    List<FromTypeExpression> finalFromTypeExpressions =
+        matchUnnestExpressionsWithFilters(
+            query.getFromTypeExpressions(), andFilters, finalAndFilters);
+
+    // return modified query if any change
+    return andFilters.size() == finalAndFilters.size()
+        ? query
+        : new TransformedQueryBuilder(query)
+            .setFilter(prepareFinalAndFiltersChain(finalAndFilters))
+            .setFromClauses(finalFromTypeExpressions)
+            .build();
+  }
+
+  private FilterTypeExpression prepareFinalAndFiltersChain(
+      List<FilterTypeExpression> finalFilters) {
+    return finalFilters.stream().reduce(null, PostgresUnnestQueryTransformer::buildAndFilter);
+  }
+
+  private static FilterTypeExpression buildAndFilter(
+      FilterTypeExpression left, FilterTypeExpression right) {
+    if (left == null) return right;
+    if (right == null) return left;
+    return LogicalExpression.builder()
+        .operator(LogicalOperator.AND)
+        .operand(left)
+        .operand(right)
+        .build();
+  }
+
+  private static List<FromTypeExpression> matchUnnestExpressionsWithFilters(
+      List<FromTypeExpression> fromTypeExpressions,
+      List<FilterTypeExpression> andFilters,
+      List<FilterTypeExpression> finalAndFilters) {
+
+    List<FromTypeExpression> finalFromTypeExpressions = Lists.newArrayList(fromTypeExpressions);
+    FilterIdentifierProvider filterIdentifierProvider = new FilterIdentifierProvider();
+    UnnestExpressionProvider unnestExpressionProvider = new UnnestExpressionProvider();
+
+    for (FilterTypeExpression filterTypeExpression : andFilters) {
+      Optional<UnnestExpression> matchedUnnestExpression =
+          getMatchedUnnestExpression(
+              finalFromTypeExpressions,
+              filterTypeExpression,
+              unnestExpressionProvider,
+              filterIdentifierProvider);
+
+      if (matchedUnnestExpression.isPresent()) {
+        UnnestExpression unnestExpression =
+            getBuildUnnestExpression(matchedUnnestExpression.get(), filterTypeExpression);
+        updateModifiedUnnestExpression(
+            finalFromTypeExpressions, matchedUnnestExpression.get(), unnestExpression);
+      } else {
+        finalAndFilters.add(filterTypeExpression);
+      }
+    }
+    return finalFromTypeExpressions;
+  }
+
+  private static void updateModifiedUnnestExpression(
+      List<FromTypeExpression> finalFromTypeExpressions,
+      FromTypeExpression org,
+      FromTypeExpression modified) {
+    int foundAt =
+        IntStream.range(0, finalFromTypeExpressions.size())
+            .filter(i -> finalFromTypeExpressions.get(i).equals(org))
+            .findFirst()
+            .getAsInt();
+    finalFromTypeExpressions.set(foundAt, modified);
+  }
+
+  private static Optional<UnnestExpression> getMatchedUnnestExpression(
+      List<FromTypeExpression> fromTypeExpressions,
+      FilterTypeExpression filterTypeExpression,
+      UnnestExpressionProvider unnestExpressionProvider,
+      FilterIdentifierProvider filterIdentifierProvider) {
+    return fromTypeExpressions.stream()
+        .map(
+            fromTypeExpression ->
+                (UnnestExpression) fromTypeExpression.accept(unnestExpressionProvider))
+        .filter(
+            unnestExpression ->
+                filterTypeExpression.accept(
+                    new FilterToUnnestExpressionMatcher(
+                        filterIdentifierProvider, unnestExpression)))
+        .max(Comparator.comparing(u -> u.getIdentifierExpression().getName()));
+  }
+
+  private static UnnestExpression getBuildUnnestExpression(
+      UnnestExpression matchedUnnestExpression, FilterTypeExpression filterTypeExpression) {
+    return UnnestExpression.builder()
+        .identifierExpression(matchedUnnestExpression.getIdentifierExpression())
+        .preserveNullAndEmptyArrays(matchedUnnestExpression.isPreserveNullAndEmptyArrays())
+        .filterTypeExpression(
+            buildAndFilter(filterTypeExpression, matchedUnnestExpression.getFilterTypeExpression()))
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static class UnnestExpressionProvider implements FromTypeExpressionVisitor {
+
+    @Override
+    public UnnestExpression visit(UnnestExpression unnestExpression) {
+      return unnestExpression;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static class FilterIdentifierProvider implements SelectTypeExpressionVisitor {
+
+    @Override
+    public List<String> visit(AggregateExpression expression) {
+      return expression.getExpression().accept(this);
+    }
+
+    @Override
+    public List<String> visit(ConstantExpression expression) {
+      return List.of();
+    }
+
+    @Override
+    public List<String> visit(FunctionExpression expression) {
+      return expression.getOperands().stream()
+          .map(exp -> exp.<List<String>>accept(this))
+          .flatMap(Collection::stream)
+          .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> visit(IdentifierExpression expression) {
+      return List.of(expression.getName());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static class AndFiltersCollector implements FilterTypeExpressionVisitor {
+
+    @Override
+    public List<FilterTypeExpression> visit(LogicalExpression expression) {
+      if (expression.getOperator().equals(LogicalOperator.AND)) {
+        return expression.getOperands().stream()
+            .map(
+                filterTypeExpression ->
+                    filterTypeExpression.<List<FilterTypeExpression>>accept(this))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+      }
+      return List.of(expression);
+    }
+
+    @Override
+    public List<FilterTypeExpression> visit(RelationalExpression expression) {
+      return List.of(expression);
+    }
+
+    @Override
+    public List<FilterTypeExpression> visit(KeyExpression expression) {
+      return List.of(expression);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static class FilterToUnnestExpressionMatcher implements FilterTypeExpressionVisitor {
+    private final UnnestExpression unnestExpression;
+    private final FilterIdentifierProvider filterIdentifierProvider;
+
+    FilterToUnnestExpressionMatcher(
+        FilterIdentifierProvider filterIdentifierProvider, UnnestExpression unnestExpression) {
+      this.unnestExpression = unnestExpression;
+      this.filterIdentifierProvider = filterIdentifierProvider;
+    }
+
+    @Override
+    public Boolean visit(LogicalExpression expression) {
+      if (expression.getOperator().equals(LogicalOperator.OR)) {
+        return expression.getOperands().stream()
+            .filter(filterTypeExpression -> filterTypeExpression.accept(this))
+            .findFirst()
+            .isEmpty();
+      }
+      return false;
+    }
+
+    @Override
+    public Boolean visit(RelationalExpression expression) {
+      List<String> lhs = expression.getLhs().accept(filterIdentifierProvider);
+      return lhs.stream()
+          .anyMatch(p -> p.contains(unnestExpression.getIdentifierExpression().getName()));
+    }
+
+    @Override
+    public Boolean visit(KeyExpression expression) {
+      String lhs = expression.getKey().toString();
+      return (lhs.contains(unnestExpression.getIdentifierExpression().getName()));
+    }
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
@@ -205,6 +205,11 @@ public class Query {
       return this;
     }
 
+    public QueryBuilder clearFilter() {
+      this.filterBuilder = null;
+      return this;
+    }
+
     public QueryBuilder setAggregation(final Aggregation aggregation) {
       this.aggregationBuilder = aggregation.toBuilder();
       return this;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/query/Query.java
@@ -205,7 +205,7 @@ public class Query {
       return this;
     }
 
-    public QueryBuilder clearFilter() {
+    protected QueryBuilder clearFilter() {
       this.filterBuilder = null;
       return this;
     }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/query/transform/TransformedQueryBuilder.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/query/transform/TransformedQueryBuilder.java
@@ -17,6 +17,11 @@ public final class TransformedQueryBuilder extends Query.QueryBuilder {
     copyFromClauses(query);
   }
 
+  public TransformedQueryBuilder clearFilter() {
+    super.clearFilter();
+    return this;
+  }
+
   private void copySelections(final Query query) {
     // Iterate through elements to ensure deep-copy
     query.getSelections().forEach(this::addSelection);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -763,6 +763,144 @@ public class PostgresQueryParserTest {
   }
 
   @Test
+  void testUnnestWithRegularFilterAndNullAndEmptyPreserved() {
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("price"))
+            .addSelection(IdentifierExpression.of("sales.city"))
+            .addSelection(IdentifierExpression.of("sales.medium.type"))
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales"), true))
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales.medium"), true))
+            .setFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .build();
+
+    PostgresQueryParser postgresQueryParser =
+        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+    String sql = postgresQueryParser.parse();
+
+    assertEquals(
+        "With \n"
+            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
+            + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
+            + "SELECT document->'item' AS item, document->'price' AS price, sales->'city' AS sales_dot_city, sales_dot_medium->'type' AS sales_dot_medium_dot_type FROM table2 WHERE sales_dot_medium->>'type' = ?",
+        sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    assertEquals(2, params.getObjectParams().size());
+  }
+
+  @Test
+  void testUnnestWithRegularAndUnnestFilterAndNullAndEmptyPreserved() {
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("quantity"))
+            .addSelection(IdentifierExpression.of("sales.city"))
+            .addSelection(IdentifierExpression.of("sales.medium.type"))
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales"), true))
+            .addFromClause(
+                UnnestExpression.builder()
+                    .identifierExpression(IdentifierExpression.of("sales.medium"))
+                    .preserveNullAndEmptyArrays(true)
+                    .filterTypeExpression(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .setFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .build();
+
+    PostgresQueryParser postgresQueryParser =
+        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+    String sql = postgresQueryParser.parse();
+
+    assertEquals(
+        "With \n"
+            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
+            + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
+            + "SELECT document->'item' AS item, document->'quantity' AS quantity, sales->'city' AS sales_dot_city, sales_dot_medium->'type' AS sales_dot_medium_dot_type FROM table2 WHERE (sales_dot_medium->>'type' = ?) AND (sales_dot_medium->>'type' = ?)",
+        sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    assertEquals(3, params.getObjectParams().size());
+  }
+
+  @Test
+  void testUnnestWithRegularAndDifferentUnnestFilterAndNullAndEmptyPreserved() {
+    org.hypertrace.core.documentstore.query.Query query =
+        org.hypertrace.core.documentstore.query.Query.builder()
+            .addSelection(IdentifierExpression.of("item"))
+            .addSelection(IdentifierExpression.of("quantity"))
+            .addSelection(IdentifierExpression.of("sales.city"))
+            .addSelection(IdentifierExpression.of("sales.medium.type"))
+            .addFromClause(UnnestExpression.of(IdentifierExpression.of("sales"), true))
+            .addFromClause(
+                UnnestExpression.builder()
+                    .identifierExpression(IdentifierExpression.of("sales.medium"))
+                    .preserveNullAndEmptyArrays(true)
+                    .filterTypeExpression(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.channel"),
+                            EQ,
+                            ConstantExpression.of("online")))
+                    .build())
+            .setFilter(
+                LogicalExpression.builder()
+                    .operator(AND)
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("quantity"), GT, ConstantExpression.of(5)))
+                    .operand(
+                        RelationalExpression.of(
+                            IdentifierExpression.of("sales.medium.type"),
+                            EQ,
+                            ConstantExpression.of("retail")))
+                    .build())
+            .build();
+
+    PostgresQueryParser postgresQueryParser =
+        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+    String sql = postgresQueryParser.parse();
+
+    assertEquals(
+        "With \n"
+            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
+            + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
+            + "SELECT document->'item' AS item, document->'quantity' AS quantity, sales->'city' AS sales_dot_city, sales_dot_medium->'type' AS sales_dot_medium_dot_type FROM table2 WHERE (sales_dot_medium->>'type' = ?) AND (sales_dot_medium->>'channel' = ?)",
+        sql);
+
+    Params params = postgresQueryParser.getParamsBuilder().build();
+    assertEquals(3, params.getObjectParams().size());
+  }
+
+  @Test
   void testQueryQ1AggregationFilterWithStringAlongWithNonAliasFields() {
     org.hypertrace.core.documentstore.query.Query query =
         org.hypertrace.core.documentstore.query.Query.builder()


### PR DESCRIPTION
## Description
This PR handles the backward compatibility scenarios between two implementations of this interface between Postgres and Mongo.

There is no way of accessing an item of a JSON array without w/o index expression. So, that results in the no match.
As a below example, If we try to access, `sales.city` it will return null as there is no key at `sales`.
```
{ "item":"Soap", "sales":[ { "city":"delhi" } ] }
```

However, as mongo supports -EQ- operator on an array field that behaves as contains internally,
`sales.city-EQ-delhi` is a valid filter expression. Ideally, the client should have expressed contains as `sales-CONTAINS-{"city":"delhi"}`.
 
To support the above in-compatibility w/o affecting the client, for now,  we are adding a query pre-processor for filter expression that will move any applied filter on the array field to unnest expression filter.


### Testing
- Existing tests pass
- Added new tests both at unit and integration level

### Example Query:
```
SELECT `item`, 
`quantity`, `sales.city`, 
`sales.medium.type` 
FROM <implicit_collection>, UNNEST(`sales`, true, null), UNNEST(`sales.medium`, true, null) 
WHERE (`quantity` > 5) AND (`sales.medium.type` = 'retail')
```

**Mongo Query:** No change as is.
```
db.mytest.aggregate([
{"$match": {"$and": [{"quantity": {"$gt": 5}}, {"sales.medium.type": "retail"}]}}, 
{"$unwind": {"preserveNullAndEmptyArrays": true, "path": "$sales"}}, 
{"$unwind": {"preserveNullAndEmptyArrays": true, "path": "$sales.medium"}}, 
{"$project": {"item": 1, "quantity": 1, "sales.medium.type": 1, "sales.city": 1}}
])
```

**Postgres Query:**  See the array filter is moved to unnest, so it will be applied after array field expansion.
```
With
table0 as (SELECT * from mytest WHERE CAST (document->>'quantity' AS NUMERIC) > ?),
table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),
table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)
SELECT document->'item' AS item, sales->'city' AS sales_dot_city, sales_dot_medium->'type' AS sales_dot_medium_dot_type FROM table2 WHERE sales_dot_medium->>'type' = ?",
```

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
