### PR TITLE
fix: contains mongo query parsing

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
@@ -58,12 +58,16 @@ class MongoQueryParser {
           map.put(filter.getFieldName(), new BasicDBObject("$in", value));
           break;
         case CONTAINS:
-          map.put(filter.getFieldName(), new BasicDBObject("$elemMatch", filter.getValue()));
+          map.put(
+              filter.getFieldName(),
+              new BasicDBObject("$elemMatch", new BasicDBObject("$eq", filter.getValue())));
           break;
         case NOT_CONTAINS:
           map.put(
               filter.getFieldName(),
-              new BasicDBObject("$not", new BasicDBObject("$elemMatch", filter.getValue())));
+              new BasicDBObject(
+                  "$not",
+                  new BasicDBObject("$elemMatch", new BasicDBObject("$eq", filter.getValue()))));
           break;
         case GT:
           map.put(filter.getFieldName(), new BasicDBObject("$gt", value));

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoQueryParser.java
@@ -60,14 +60,13 @@ class MongoQueryParser {
         case CONTAINS:
           map.put(
               filter.getFieldName(),
-              new BasicDBObject("$elemMatch", new BasicDBObject("$eq", filter.getValue())));
+              new BasicDBObject("$elemMatch", new BasicDBObject("$eq", value)));
           break;
         case NOT_CONTAINS:
           map.put(
               filter.getFieldName(),
               new BasicDBObject(
-                  "$not",
-                  new BasicDBObject("$elemMatch", new BasicDBObject("$eq", filter.getValue()))));
+                  "$not", new BasicDBObject("$elemMatch", new BasicDBObject("$eq", value))));
           break;
         case GT:
           map.put(filter.getFieldName(), new BasicDBObject("$gt", value));

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryParserTest.java
@@ -78,14 +78,17 @@ class MongoQueryParserTest {
     {
       Filter filter = new Filter(Filter.Op.CONTAINS, "key1", "abc");
       Map<String, Object> query = MongoQueryParser.parseFilter(filter);
-      assertEquals(new BasicDBObject("$elemMatch", "abc"), query.get("key1"));
+      assertEquals(
+          new BasicDBObject("$elemMatch", new BasicDBObject("$eq", "abc")), query.get("key1"));
     }
 
     {
       Filter filter = new Filter(Op.NOT_CONTAINS, "key1", "abc");
       Map<String, Object> query = MongoQueryParser.parseFilter(filter);
       assertEquals(
-          new BasicDBObject("$not", new BasicDBObject("$elemMatch", "abc")), query.get("key1"));
+          new BasicDBObject(
+              "$not", new BasicDBObject("$elemMatch", new BasicDBObject("$eq", "abc"))),
+          query.get("key1"));
     }
 
     {


### PR DESCRIPTION
## Description
This PR adds a fix for CONTAINS filter operator mongo query parsing.
`$elemMatch` expects an object as opposed to the direct value to be compared with,
Eg:
```
{
  "key1": {
       "$elemMatch": { $eq: "val1"}
   }
}
```
as opposed to
```
{
  "key1": {
       "$elemMatch": "val1"
   }
}
```

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests for the same.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
