### PR TITLE
chore: downgrade logger, add dep check and upgrade vulns

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,47 +9,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
        # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
       
-      - name: create checksum file
-        uses: hypertrace/github-actions/checksum@main
-
-      - name: Cache packages
-        id: cache-packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle
-          key: gradle-packages-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/checksum.txt') }}
-          restore-keys: |
-            gradle-packages-${{ runner.os }}-${{ github.job }}
-            gradle-packages-${{ runner.os }}
-
       - name: Build with Gradle
         uses: hypertrace/github-actions/gradle@main
         with: 
           args: build
 
-  snyk-scan:
-    runs-on: ubuntu-20.04
-    steps:
-    # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
-      - name: Check out code
-        uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          fetch-depth: 0
-      - name: Setup snyk
-        uses: snyk/actions/setup@0.3.0
-      - name: Snyk test
-        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$'
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,46 +7,33 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
-      - name: create checksum file
-        uses: hypertrace/github-actions/checksum@main
-
-      - name: Cache packages
-        id: cache-packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle
-          key: gradle-packages-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/checksum.txt') }}
-          restore-keys: |
-            gradle-packages-${{ runner.os }}-${{ github.job }}
-            gradle-packages-${{ runner.os }}
 
       - name: Unit test
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           name: unit test reports
           fail_ci_if_error: true
           flags: unit
-  
+
       - name: Integration test
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: jacocoIntegrationTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           name: integration test reports
           fail_ci_if_error: true
@@ -54,19 +41,24 @@ jobs:
 
       - name: copy test reports
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: copyAllReports --output-dir=/tmp/test-reports
 
       - name: Archive test reports
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: /tmp/test-reports
         if: always()
-     
+
       - name: Publish Unit Test Results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ./**/build/test-results/**/*.xml
+  dependency-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dependency Check
+        uses: hypertrace/github-actions/dependency-check@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,25 +8,13 @@ on:
 
 jobs:
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: create checksum file
-        uses: hypertrace/github-actions/checksum@main
-
-      - name: Cache packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle
-          key: gradle-packages-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/checksum.txt') }}
-          restore-keys: |
-            gradle-packages-${{ runner.os }}-${{ github.job }}
-            gradle-packages-${{ runner.os }}
 
       - name: publish java artifacts
         uses: hypertrace/github-actions/gradle@main

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("org.hypertrace.ci-utils-plugin") version "0.3.0"
   id("org.hypertrace.publish-plugin") version "1.0.2" apply false
   id("org.hypertrace.code-style-plugin") version "1.1.0" apply false
+  id("org.owasp.dependencycheck") version "8.2.1"
 }
 
 subprojects {
@@ -17,4 +18,11 @@ subprojects {
   }
 
   apply(plugin = "org.hypertrace.code-style-plugin")
+}
+
+dependencyCheck {
+  format = org.owasp.dependencycheck.reporting.ReportGenerator.Format.ALL.toString()
+  suppressionFile = "owasp-suppressions.xml"
+  scanConfigurations.add("runtimeClasspath")
+  failBuildOnCVSS = 3.0F
 }

--- a/document-store/build.gradle.kts
+++ b/document-store/build.gradle.kts
@@ -14,10 +14,10 @@ dependencies {
   implementation("org.postgresql:postgresql:42.5.4")
   implementation("org.mongodb:mongodb-driver-sync:4.9.0")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.15.1")
-  implementation("org.slf4j:slf4j-api:2.0.5")
+  implementation("org.slf4j:slf4j-api:1.7.36")
   implementation("org.apache.commons:commons-lang3:3.12.0")
   implementation("net.jodah:failsafe:2.4.4")
-  implementation("com.google.guava:guava:31.1-jre")
+  implementation("com.google.guava:guava:32.0.1-jre")
   implementation("org.apache.commons:commons-dbcp2:2.9.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions> 


### PR DESCRIPTION
## Description

Downgrade the slf4j api as that will require all consumers to upgrade their logging runtime or otherwise silently break logging. We should be upgrading in the other direction, all consumers then libs.

While fixing that updated CI and switched to owasp checker