### PR TITLE
added space to the allowed regex for sub doc path

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/DocStoreQueryV1Test.java
@@ -1837,6 +1837,34 @@ public class DocStoreQueryV1Test {
     }
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(AllProvider.class)
+  void testValidSubDocumentPathsWithUpdate(final String datastoreName) throws IOException {
+    final Collection collection = getCollection(datastoreName, UPDATABLE_COLLECTION_NAME);
+    createCollectionData("query/test_valid_sub_doc_path.json", UPDATABLE_COLLECTION_NAME);
+    Query query =
+        Query.builder()
+            .setFilter(
+                RelationalExpression.of(
+                    IdentifierExpression.of("props.seller.name"),
+                    EQ,
+                    ConstantExpression.of("Metro Chemicals Pvt. Ltd.")))
+            .build();
+
+    List<SubDocumentUpdate> updates =
+        List.of(
+            SubDocumentUpdate.builder()
+                .subDocument("props.seller.alias name")
+                .operator(SET)
+                .subDocumentValue(SubDocumentValue.of("metro.in"))
+                .build());
+    final CloseableIterator<Document> iterator =
+        collection.bulkUpdate(
+            query, updates, UpdateOptions.builder().returnDocumentType(AFTER_UPDATE).build());
+    assertDocsAndSizeEqualWithoutOrder(
+        datastoreName, iterator, "query/test_valid_sub_doc_path_updated.json", 1);
+  }
+
   @Nested
   class AtomicUpdateTest {
     @ParameterizedTest

--- a/document-store/src/integrationTest/resources/query/test_valid_sub_doc_path.json
+++ b/document-store/src/integrationTest/resources/query/test_valid_sub_doc_path.json
@@ -1,0 +1,53 @@
+[
+  {
+    "_id": 1,
+    "item": "Soap",
+    "price": 10,
+    "quantity": 2,
+    "date": "2014-03-01T08:00:00Z",
+    "props": {
+      "brand": "Dettol",
+      "size": "M",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd.",
+        "alias name": "metro.in",
+        "address": {
+          "city": "Mumbai",
+          "pincode": 400004
+        }
+      }
+    },
+    "sales": [
+      {
+        "city": "delhi",
+        "medium": [
+          {
+            "type": "distributionChannel",
+            "volume": 1000
+          },
+          {
+            "type": "retail",
+            "volume": 500
+          },
+          {
+            "type": "online",
+            "volume": 1000
+          }
+        ]
+      },
+      {
+        "city": "pune",
+        "medium": [
+          {
+            "type": "distributionChannel",
+            "volume": 300
+          },
+          {
+            "type": "online",
+            "volume": 2000
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/document-store/src/integrationTest/resources/query/test_valid_sub_doc_path_updated.json
+++ b/document-store/src/integrationTest/resources/query/test_valid_sub_doc_path_updated.json
@@ -1,0 +1,52 @@
+[
+  {
+    "item": "Soap",
+    "price": 10,
+    "quantity": 2,
+    "date": "2014-03-01T08:00:00Z",
+    "props": {
+      "brand": "Dettol",
+      "size": "M",
+      "seller": {
+        "name": "Metro Chemicals Pvt. Ltd.",
+        "alias name": "metro.in",
+        "address": {
+          "city": "Mumbai",
+          "pincode": 400004
+        }
+      }
+    },
+    "sales": [
+      {
+        "city": "delhi",
+        "medium": [
+          {
+            "type": "distributionChannel",
+            "volume": 1000
+          },
+          {
+            "type": "retail",
+            "volume": 500
+          },
+          {
+            "type": "online",
+            "volume": 1000
+          }
+        ]
+      },
+      {
+        "city": "pune",
+        "medium": [
+          {
+            "type": "distributionChannel",
+            "volume": 300
+          },
+          {
+            "type": "online",
+            "volume": 2000
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
@@ -18,7 +18,7 @@ public class SubDocument {
 
   private static final Set<String> IMPLICIT_PATHS = Set.of(CREATED_TIME, LAST_UPDATED_TIME);
   private static final Pattern ALLOWED_CHARACTERS =
-      Pattern.compile("^[a-zA-Z0-9_]+(.[a-zA-Z0-9_]+)*$");
+      Pattern.compile("^[a-zA-Z0-9_]+(.[a-zA-Z0-9_ ]+)*$");
 
   String path;
 

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/model/subdoc/SubDocumentTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/model/subdoc/SubDocumentTest.java
@@ -18,7 +18,9 @@ class SubDocumentTest {
         Arguments.of("1234567890"),
         Arguments.of("price.quantity"),
         Arguments.of("67aa7623-fc40-4112-b958-cbd6d4c077b1"),
-        Arguments.of("first_name"));
+        Arguments.of("first_name"),
+        Arguments.of(
+            "apiResponseSummaryDetails.Post /workshop/api/shop/orders/return_order.responseCodeCount.0"));
   }
 
   @MethodSource


### PR DESCRIPTION
## Description
Added support for spaces in the sub-doc path. Currently spaces are not allowed in sub-doc path.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added test case to validate sub doc path with a space.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
