### PR TITLE
fix: update support for postgres collection names with schema identif…

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/metric/postgres/PostgresDocStoreMetricProvider.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/metric/postgres/PostgresDocStoreMetricProvider.java
@@ -25,7 +25,7 @@ public class PostgresDocStoreMetricProvider extends BaseDocStoreMetricProviderIm
       "num.active.postgres.connections";
   private static final String APP_NAME_LABEL = "app_name";
   private static final String APPLICATION_COLUMN_NAME = "application_name";
-  private static final String PG_STAT_ACTIVITY_TABLE = "pg_stat_activity";
+  private static final String PG_STAT_ACTIVITY_TABLE = "pg_catalog.pg_stat_activity";
 
   private final String applicationNameInCurrentConnection;
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -72,7 +73,12 @@ public class PostgresDatastore implements Datastore {
       DatabaseMetaData metaData = client.getConnection().getMetaData();
       ResultSet tables = metaData.getTables(null, null, "%", new String[] {"TABLE"});
       while (tables.next()) {
-        collections.add(database + "." + tables.getString("TABLE_NAME"));
+        Optional<String> nonPublicSchema =
+            Optional.ofNullable(tables.getString("TABLE_SCHEM"))
+                .filter(schema -> !schema.equals("public"));
+        String tableName = tables.getString("TABLE_NAME");
+        String fullTableString = nonPublicSchema.map(s -> s + "." + tableName).orElse(tableName);
+        collections.add(database + "." + fullTableString);
       }
     } catch (SQLException e) {
       LOGGER.error("Exception getting postgres metadata");
@@ -82,6 +88,8 @@ public class PostgresDatastore implements Datastore {
 
   @Override
   public boolean createCollection(String collectionName, Map<String, String> options) {
+    final PostgresTableIdentifier identifier = PostgresTableIdentifier.parse(collectionName);
+    identifier.getSchema().ifPresent(this::createSchemaIfNotExists);
     String createTableSQL =
         String.format(
             "CREATE TABLE %s ("
@@ -90,32 +98,45 @@ public class PostgresDatastore implements Datastore {
                 + "%s TIMESTAMPTZ NOT NULL DEFAULT NOW(),"
                 + "%s TIMESTAMPTZ NOT NULL DEFAULT NOW()"
                 + ");",
-            collectionName, ID, DOCUMENT, CREATED_AT, UPDATED_AT);
+            identifier, ID, DOCUMENT, CREATED_AT, UPDATED_AT);
     try (PreparedStatement preparedStatement =
         client.getConnection().prepareStatement(createTableSQL)) {
       preparedStatement.executeUpdate();
     } catch (SQLException e) {
-      LOGGER.error("Exception creating table name: {}", collectionName);
+      LOGGER.error("Exception creating table name: {}", identifier);
       return false;
     }
     return true;
   }
 
+  private void createSchemaIfNotExists(@NonNull String schema) {
+    final String createSchemaSql = String.format("CREATE SCHEMA IF NOT EXISTS %s;", schema);
+    try (PreparedStatement preparedStatement =
+        client.getConnection().prepareStatement(createSchemaSql)) {
+      preparedStatement.execute();
+    } catch (SQLException e) {
+      LOGGER.error("Exception creating schema: {}", schema);
+    }
+  }
+
   @Override
   public boolean deleteCollection(String collectionName) {
-    String dropTableSQL = String.format("DROP TABLE IF EXISTS %s", collectionName);
+    PostgresTableIdentifier tableIdentifier = PostgresTableIdentifier.parse(collectionName);
+    String dropTableSQL = String.format("DROP TABLE IF EXISTS %s", tableIdentifier);
     try (PreparedStatement preparedStatement =
         client.getConnection().prepareStatement(dropTableSQL)) {
       int result = preparedStatement.executeUpdate();
       return result >= 0;
     } catch (SQLException e) {
-      LOGGER.error("Exception deleting table name: {}", collectionName);
+      LOGGER.error("Exception deleting table name: {}", tableIdentifier);
     }
     return false;
   }
 
   @Override
   public Collection getCollection(String collectionName) {
+    // FIXME - need to figure out listing schema tables before merging
+    PostgresTableIdentifier tableIdentifier = PostgresTableIdentifier.parse(collectionName);
     Set<String> tables = listCollections();
     if (!tables.contains(collectionName)) {
       createCollection(collectionName, null);
@@ -125,9 +146,9 @@ public class PostgresDatastore implements Datastore {
 
   @Override
   public boolean healthCheck() {
-    String healtchCheckSQL = "SELECT 1;";
+    String healthCheckSql = "SELECT 1;";
     try (PreparedStatement preparedStatement =
-        client.getConnection().prepareStatement(healtchCheckSQL)) {
+        client.getConnection().prepareStatement(healthCheckSql)) {
       return preparedStatement.execute();
     } catch (SQLException e) {
       LOGGER.error("Exception executing health check");

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
@@ -68,6 +68,13 @@ public class PostgresDatastore implements Datastore {
   /** @return Returns Tables for a particular database */
   @Override
   public Set<String> listCollections() {
+    //  Relevant bits of the table metadata schema:
+    //  TABLE_CAT String => table catalog (may be null)
+    //  TABLE_SCHEM String => table schema (may be null)
+    //  TABLE_NAME String => table name
+    //  TABLE_TYPE String => table type. Typical types are "TABLE", "VIEW", "SYSTEM TABLE", "GLOBAL
+    // TEMPORARY", "LOCAL TEMPORARY", "ALIAS", "SYNONYM".
+    //
     Set<String> collections = new HashSet<>();
     try {
       DatabaseMetaData metaData = client.getConnection().getMetaData();

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresDatastore.java
@@ -142,8 +142,6 @@ public class PostgresDatastore implements Datastore {
 
   @Override
   public Collection getCollection(String collectionName) {
-    // FIXME - need to figure out listing schema tables before merging
-    PostgresTableIdentifier tableIdentifier = PostgresTableIdentifier.parse(collectionName);
     Set<String> tables = listCollections();
     if (!tables.contains(collectionName)) {
       createCollection(collectionName, null);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresQueryExecutor.java
@@ -18,12 +18,12 @@ import org.hypertrace.core.documentstore.query.Query;
 @Slf4j
 @AllArgsConstructor
 public class PostgresQueryExecutor {
-  private final String collectionName;
+  private final PostgresTableIdentifier tableIdentifier;
 
   public CloseableIterator<Document> execute(final Connection connection, final Query query) {
     final org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser queryParser =
         new org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser(
-            collectionName, transformAndLog(query));
+            tableIdentifier, transformAndLog(query));
     final String sqlQuery = queryParser.parse();
     try {
       final PreparedStatement preparedStatement =

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresTableIdentifier.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresTableIdentifier.java
@@ -1,0 +1,43 @@
+package org.hypertrace.core.documentstore.postgres;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+public class PostgresTableIdentifier {
+
+  @Nullable private final String schema;
+
+  @Getter @Nonnull private final String quotedTable;
+
+  public Optional<String> getSchema() {
+    return Optional.ofNullable(this.schema);
+  }
+
+  PostgresTableIdentifier(String tableName) {
+    this(null, tableName);
+  }
+
+  PostgresTableIdentifier(@Nullable String schema, @Nonnull String tableName) {
+    this.schema = schema;
+    this.quotedTable = "\"" + tableName + "\"";
+  }
+
+  public static PostgresTableIdentifier parse(String tableString) {
+    String[] tableComponents = tableString.split("\\.", 2);
+    if (tableComponents.length == 2) {
+      return new PostgresTableIdentifier(tableComponents[0], tableComponents[1]);
+    }
+    return new PostgresTableIdentifier(tableComponents[0]);
+  }
+
+  @Override
+  public String toString() {
+    return this.getSchema()
+        .map(schema -> schema + "." + this.getQuotedTable())
+        .orElseGet(this::getQuotedTable);
+  }
+}

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresTableIdentifier.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresTableIdentifier.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class PostgresTableIdentifier {
 
+  // If not specified, no schema will be used. By default, postgres treats this as the "public"
+  // schema.
   @Nullable private final String schema;
 
   @Getter @Nonnull private final String quotedTable;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParser.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hypertrace.core.documentstore.postgres.Params;
 import org.hypertrace.core.documentstore.postgres.Params.Builder;
+import org.hypertrace.core.documentstore.postgres.PostgresTableIdentifier;
 import org.hypertrace.core.documentstore.postgres.query.v1.transformer.FieldToPgColumnTransformer;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresAggregationFilterTypeExpressionVisitor;
 import org.hypertrace.core.documentstore.postgres.query.v1.vistors.PostgresFilterTypeExpressionVisitor;
@@ -22,9 +23,10 @@ import org.hypertrace.core.documentstore.query.Pagination;
 import org.hypertrace.core.documentstore.query.Query;
 
 public class PostgresQueryParser {
+
   private static final String ALL_SELECTIONS = "*";
 
-  @Getter private final String collection;
+  @Getter private final PostgresTableIdentifier tableIdentifier;
   @Getter private final Query query;
 
   @Setter String finalTableName;
@@ -42,10 +44,10 @@ public class PostgresQueryParser {
   @Getter private final Map<String, String> pgColumnNames = new HashMap<>();
   @Getter private final FieldToPgColumnTransformer toPgColumnTransformer;
 
-  public PostgresQueryParser(String collection, Query query) {
-    this.collection = collection;
+  public PostgresQueryParser(PostgresTableIdentifier tableIdentifier, Query query) {
+    this.tableIdentifier = tableIdentifier;
     this.query = query;
-    this.finalTableName = collection;
+    this.finalTableName = tableIdentifier.toString();
     toPgColumnTransformer = new FieldToPgColumnTransformer(this);
   }
 
@@ -94,7 +96,7 @@ public class PostgresQueryParser {
 
     final StringBuilder queryBuilder = new StringBuilder();
     queryBuilder.append("SELECT ").append(selections);
-    queryBuilder.append(" FROM ").append(collection);
+    queryBuilder.append(" FROM ").append(tableIdentifier);
     optionalFilter.ifPresent(filter -> queryBuilder.append(" WHERE ").append(filter));
     optionalOrderBy.ifPresent(orderBy -> queryBuilder.append(" ORDER BY ").append(orderBy));
     queryBuilder.append(" LIMIT 1");

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFromTypeExpressionVisitor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/query/v1/vistors/PostgresFromTypeExpressionVisitor.java
@@ -10,6 +10,7 @@ import org.hypertrace.core.documentstore.postgres.query.v1.PostgresQueryParser;
 import org.hypertrace.core.documentstore.postgres.utils.PostgresUtils;
 
 public class PostgresFromTypeExpressionVisitor implements FromTypeExpressionVisitor {
+
   private static final String QUERY_FMT = "With \n%s\n%s\n";
 
   private static final String TABLE0_QUERY_FMT = "table0 as (SELECT * from %s),";
@@ -76,6 +77,7 @@ public class PostgresFromTypeExpressionVisitor implements FromTypeExpressionVisi
     }
 
     String table0Query = prepareTable0Query(postgresQueryParser);
+
     postgresQueryParser.setFinalTableName("table" + postgresQueryParser.getPgColumnNames().size());
     return Optional.of(String.format(QUERY_FMT, table0Query, childList));
   }
@@ -86,7 +88,7 @@ public class PostgresFromTypeExpressionVisitor implements FromTypeExpressionVisi
 
     return whereFilter.isPresent()
         ? String.format(
-            TABLE0_QUERY_FMT_WHERE, postgresQueryParser.getCollection(), whereFilter.get())
-        : String.format(TABLE0_QUERY_FMT, postgresQueryParser.getCollection());
+            TABLE0_QUERY_FMT_WHERE, postgresQueryParser.getTableIdentifier(), whereFilter.get())
+        : String.format(TABLE0_QUERY_FMT, postgresQueryParser.getTableIdentifier());
   }
 }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -89,10 +89,10 @@ class PostgresCollectionTest {
     when(mockClient.getConnection()).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(
             String.format(
-                "INSERT INTO %s (id, document, created_at) "
+                "INSERT INTO \"%s\" (id, document, created_at) "
                     + "VALUES (?, ?::jsonb, NOW()) "
                     + "ON CONFLICT(id) DO UPDATE SET "
-                    + "document = jsonb_set(?::jsonb, '{createdTime}', %s.document->'createdTime'), "
+                    + "document = jsonb_set(?::jsonb, '{createdTime}', \"%s\".document->'createdTime'), "
                     + "updated_at = NOW() "
                     + "RETURNING created_at = NOW() AS created_now_alias",
                 COLLECTION_NAME, COLLECTION_NAME)))
@@ -129,7 +129,7 @@ class PostgresCollectionTest {
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\", "
                 + "id AS _implicit_id "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -166,15 +166,15 @@ class PostgresCollectionTest {
                 + "id, "
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
-                + "(SELECT id, document FROM %s AS t0 WHERE id = ?) "
+                + "(SELECT id, document FROM \"%s\" AS t0 WHERE id = ?) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
 
@@ -229,7 +229,7 @@ class PostgresCollectionTest {
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\", "
                 + "id AS _implicit_id "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -265,15 +265,15 @@ class PostgresCollectionTest {
                 + "id, "
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
-                + "(SELECT id, document FROM %s AS t0 WHERE id = ?) "
+                + "(SELECT id, document FROM \"%s\" AS t0 WHERE id = ?) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
 
@@ -325,7 +325,7 @@ class PostgresCollectionTest {
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\", "
                 + "id AS _implicit_id "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -375,7 +375,7 @@ class PostgresCollectionTest {
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\", "
                 + "id AS _implicit_id "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -409,12 +409,12 @@ class PostgresCollectionTest {
                 + "(SELECT "
                 + "id, "
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
-                + "FROM (SELECT id, document FROM %s AS t0 WHERE id = ?)"
+                + "FROM (SELECT id, document FROM \"%s\" AS t0 WHERE id = ?)"
                 + " AS t1) AS t2) AS t3) AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
 
@@ -479,7 +479,7 @@ class PostgresCollectionTest {
                 + "document->'price' AS \"price\", "
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\" "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -517,17 +517,17 @@ class PostgresCollectionTest {
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
                 + "(SELECT id, document "
-                + "FROM %s AS t0 "
+                + "FROM \"%s\" AS t0 "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?)) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
 
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
@@ -594,17 +594,17 @@ class PostgresCollectionTest {
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
                 + "(SELECT id, document "
-                + "FROM %s AS t0 "
+                + "FROM \"%s\" AS t0 "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?)) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
 
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
@@ -648,7 +648,7 @@ class PostgresCollectionTest {
                 + "document->'price' AS \"price\", "
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\" "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -681,17 +681,17 @@ class PostgresCollectionTest {
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
                 + "(SELECT id, document "
-                + "FROM %s AS t0 "
+                + "FROM \"%s\" AS t0 "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?)) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
 
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);
@@ -741,7 +741,7 @@ class PostgresCollectionTest {
                 + "document->'price' AS \"price\", "
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\" "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -780,7 +780,7 @@ class PostgresCollectionTest {
                 + "document->'price' AS \"price\", "
                 + "document->'date' AS \"date\", "
                 + "document->'props' AS \"props\" "
-                + "FROM %s "
+                + "FROM \"%s\" "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?) "
                 + "ORDER BY "
@@ -812,17 +812,17 @@ class PostgresCollectionTest {
                 + "jsonb_set(COALESCE(t1.document, '{}'), ?::text[], to_jsonb(?)) AS document "
                 + "FROM "
                 + "(SELECT id, document "
-                + "FROM %s AS t0 "
+                + "FROM \"%s\" AS t0 "
                 + "WHERE (document->>'item' = ?) "
                 + "AND (document->>'date' < ?)) "
                 + "AS t1) "
                 + "AS t2) "
                 + "AS t3) "
                 + "AS t4) "
-                + "UPDATE %s "
+                + "UPDATE \"%s\" "
                 + "SET document=concatenated.document "
                 + "FROM concatenated "
-                + "WHERE %s.id=concatenated.id",
+                + "WHERE \"%s\".id=concatenated.id",
             COLLECTION_NAME, COLLECTION_NAME, COLLECTION_NAME);
 
     when(mockConnection.prepareStatement(updateQuery)).thenReturn(mockUpdatePreparedStatement);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/query/v1/PostgresQueryParserTest.java
@@ -39,6 +39,7 @@ import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.impl.UnnestExpression;
 import org.hypertrace.core.documentstore.expression.operators.FunctionOperator;
 import org.hypertrace.core.documentstore.postgres.Params;
+import org.hypertrace.core.documentstore.postgres.PostgresTableIdentifier;
 import org.hypertrace.core.documentstore.postgres.query.v1.transformer.PostgresQueryTransformer;
 import org.hypertrace.core.documentstore.query.Filter;
 import org.hypertrace.core.documentstore.query.Pagination;
@@ -50,7 +51,9 @@ import org.hypertrace.core.documentstore.query.SortingSpec;
 import org.junit.jupiter.api.Test;
 
 public class PostgresQueryParserTest {
-  private static final String TEST_COLLECTION = "testCollection";
+
+  private static final PostgresTableIdentifier TEST_TABLE =
+      PostgresTableIdentifier.parse("testCollection");
   private static final String TENANT_ID = "tenant-id";
 
   @Test
@@ -62,10 +65,12 @@ public class PostgresQueryParserTest {
                     IdentifierExpression.of("quantity"), NEQ, ConstantExpression.of(10)))
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
-        "SELECT * " + "FROM testCollection " + "WHERE CAST (document->>'quantity' AS NUMERIC) != ?",
+        "SELECT * "
+            + "FROM \"testCollection\" "
+            + "WHERE CAST (document->>'quantity' AS NUMERIC) != ?",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -90,11 +95,11 @@ public class PostgresQueryParserTest {
                     .build())
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT * "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE (CAST (document->>'quantity' AS NUMERIC) > ?) "
             + "AND (document->'props'->'seller'->'address'->>'city' = ?)",
         sql);
@@ -120,11 +125,11 @@ public class PostgresQueryParserTest {
                     .build())
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT * "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE (CAST (document->>'quantity' AS NUMERIC) >= ?) "
             + "AND (CAST (document->>'quantity' AS NUMERIC) <= ?)",
         sql);
@@ -150,11 +155,11 @@ public class PostgresQueryParserTest {
                     .build())
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT * "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE (CAST (document->>'quantity' AS NUMERIC) >= ?) "
             + "OR (CAST (document->>'quantity' AS NUMERIC) <= ?)",
         sql);
@@ -192,11 +197,11 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT * "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE (CAST (document->>'price' AS NUMERIC) >= ?) "
             + "AND ((CAST (document->>'quantity' AS NUMERIC) >= ?) "
             + "OR (CAST (document->>'quantity' AS NUMERIC) <= ?))",
@@ -216,11 +221,11 @@ public class PostgresQueryParserTest {
             .addSelection(IdentifierExpression.of("price"))
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT document->'item' AS \"item\", document->'price' AS \"price\" "
-            + "FROM testCollection",
+            + "FROM \"testCollection\"",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -241,12 +246,12 @@ public class PostgresQueryParserTest {
                 "total")
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT document->'item' AS \"item\", "
             + "CAST (document->>'price' AS NUMERIC) * CAST (document->>'quantity' AS NUMERIC) AS \"total\" "
-            + "FROM testCollection",
+            + "FROM \"testCollection\"",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -269,14 +274,14 @@ public class PostgresQueryParserTest {
                 "total")
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT document->'item' AS \"item\", "
             + "document->'props'->'brand' AS \"props_dot_brand\", "
             + "document->'props'->'seller'->'name' AS \"props_dot_seller_dot_name\", "
             + "CAST (document->>'price' AS NUMERIC) * CAST (document->>'quantity' AS NUMERIC) AS \"total\" "
-            + "FROM testCollection",
+            + "FROM \"testCollection\"",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -299,14 +304,14 @@ public class PostgresQueryParserTest {
                 "total")
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT document->'item' AS \"item\", "
             + "document->'props'->'brand' AS \"props_band\", "
             + "document->'props'->'seller'->'name' AS \"props_seller_name\", "
             + "CAST (document->>'price' AS NUMERIC) * CAST (document->>'quantity' AS NUMERIC) AS \"total\" "
-            + "FROM testCollection",
+            + "FROM \"testCollection\"",
         sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
@@ -338,7 +343,7 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
     assertEquals(
         "SELECT document->'item' AS \"item\", "
@@ -348,7 +353,7 @@ public class PostgresQueryParserTest {
             + "SUM( CAST (document->>'quantity' AS NUMERIC) ) AS \"qty_sum\", "
             + "MIN( CAST (document->>'quantity' AS NUMERIC) ) AS \"qty_min\", "
             + "MAX( CAST (document->>'quantity' AS NUMERIC) ) AS \"qty_max\" "
-            + "FROM testCollection WHERE CAST (document->>'price' AS NUMERIC) = ? "
+            + "FROM \"testCollection\" WHERE CAST (document->>'price' AS NUMERIC) = ? "
             + "GROUP BY document->'item'",
         sql);
 
@@ -377,13 +382,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)) AS \"qty_distinct\", "
             + "ARRAY_LENGTH( ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)), 1 ) AS \"qty_distinct_length\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE CAST (document->>'price' AS NUMERIC) = ? "
             + "GROUP BY document->'item'",
         sql);
@@ -416,14 +421,14 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT document->'item' AS \"item\", document->'price' AS \"price\", "
             + "ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)) AS \"quantities\", "
             + "ARRAY_LENGTH( ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)), 1 ) AS \"num_quantities\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "GROUP BY document->'item',document->'price' "
             + "HAVING ARRAY_LENGTH( ARRAY_AGG(DISTINCT CAST (document->>'quantity' AS NUMERIC)), 1 ) = ? "
             + "ORDER BY document->'item' DESC NULLS LAST",
@@ -448,13 +453,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "GROUP BY document->'item' "
             + "HAVING COUNT(DISTINCT document->>'quantity' ) <= ?",
         sql);
@@ -481,13 +486,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE CAST (document->>'price' AS NUMERIC) <= ? "
             + "GROUP BY document->'item' "
             + "HAVING COUNT(DISTINCT document->>'quantity' ) <= ?",
@@ -522,14 +527,14 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\", "
             + "document->'price' AS \"price\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "GROUP BY document->'item',document->'price' "
             + "HAVING (COUNT(DISTINCT document->>'quantity' ) <= ?) AND (CAST (document->'price' AS NUMERIC) > ?)",
         sql);
@@ -551,12 +556,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT document->'item' AS \"item\", document->'price' AS \"price\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "ORDER BY document->'price' ASC NULLS FIRST,document->'item' DESC NULLS LAST",
         sql);
 
@@ -581,13 +586,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "GROUP BY document->'item' "
             + "HAVING COUNT(DISTINCT document->>'quantity' ) <= ? "
             + "ORDER BY \"qty_count\" DESC NULLS LAST,document->'item' DESC NULLS LAST",
@@ -634,7 +639,7 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
@@ -642,7 +647,7 @@ public class PostgresQueryParserTest {
             + "document->'price' AS \"price\", "
             + "document->'quantity' AS \"quantity\", "
             + "document->'date' AS \"date\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE document->>'item' IN (?, ?, ?, ?) "
             + "ORDER BY document->'quantity' DESC NULLS LAST,document->'item' ASC NULLS FIRST "
             + "OFFSET ? LIMIT ?",
@@ -671,12 +676,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection),\n"
+            + "table0 as (SELECT * from \"testCollection\"),\n"
             + "table1 as (SELECT * from table0 t0, jsonb_array_elements(document->'sales') p1(sales)),\n"
             + "table2 as (SELECT * from table1 t1, jsonb_array_elements(sales->'medium') p2(sales_dot_medium))\n"
             + "SELECT document->'item' AS \"item\", "
@@ -703,12 +708,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection),\n"
+            + "table0 as (SELECT * from \"testCollection\"),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", "
@@ -746,12 +751,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection "
+            + "table0 as (SELECT * from \"testCollection\" "
             + "WHERE CAST (document->>'quantity' AS NUMERIC) != ?),\n"
             + "table1 as (SELECT * from table0 t0, jsonb_array_elements(document->'sales') p1(sales)),\n"
             + "table2 as (SELECT * from table1 t1, jsonb_array_elements(sales->'medium') p2(sales_dot_medium))\n"
@@ -792,12 +797,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table0 as (SELECT * from \"testCollection\" WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'price' AS \"price\", sales->'city' AS \"sales_dot_city\", sales_dot_medium->'type' AS \"sales_dot_medium_dot_type\" FROM table2 WHERE sales_dot_medium->>'type' = ?",
@@ -832,12 +837,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection),\n"
+            + "table0 as (SELECT * from \"testCollection\"),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'price' AS \"price\", sales->'city' AS \"sales_dot_city\", sales_dot_medium->'type' AS \"sales_dot_medium_dot_type\" FROM table2 WHERE (CAST (document->>'quantity' AS NUMERIC) > ?) OR (sales_dot_medium->>'type' = ?)",
@@ -881,12 +886,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'price' AS NUMERIC) > ?),\n"
+            + "table0 as (SELECT * from \"testCollection\" WHERE CAST (document->>'price' AS NUMERIC) > ?),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'price' AS \"price\", sales->'city' AS \"sales_dot_city\", sales_dot_medium->'type' AS \"sales_dot_medium_dot_type\" FROM table2 WHERE (CAST (document->>'quantity' AS NUMERIC) > ?) OR (sales_dot_medium->>'type' = ?)",
@@ -930,12 +935,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table0 as (SELECT * from \"testCollection\" WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'quantity' AS \"quantity\", sales->'city' AS \"sales_dot_city\", sales_dot_medium->'type' AS \"sales_dot_medium_dot_type\" FROM table2 WHERE (sales_dot_medium->>'type' = ?) AND (sales_dot_medium->>'type' = ?)",
@@ -979,12 +984,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table0 as (SELECT * from \"testCollection\" WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'quantity' AS \"quantity\", sales->'city' AS \"sales_dot_city\", sales_dot_medium->'type' AS \"sales_dot_medium_dot_type\" FROM table2 WHERE (sales_dot_medium->>'type' = ?) AND (sales_dot_medium->>'channel' = ?)",
@@ -1027,12 +1032,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
+            + "table0 as (SELECT * from \"testCollection\" WHERE CAST (document->>'quantity' AS NUMERIC) > ?),\n"
             + "table1 as (SELECT * from table0 t0 LEFT JOIN LATERAL jsonb_array_elements(document->'sales') p1(sales) on TRUE),\n"
             + "table2 as (SELECT * from table1 t1 LEFT JOIN LATERAL jsonb_array_elements(sales->'medium') p2(sales_dot_medium) on TRUE)\n"
             + "SELECT document->'item' AS \"item\", document->'quantity' AS \"quantity\", sales->'city' AS \"sales_dot_city\" FROM table2 WHERE (sales->>'channel' = ?) AND (sales->>'city' = ?)",
@@ -1066,13 +1071,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\", document->'price' AS \"price\" "
-            + "FROM testCollection GROUP BY document->'item',document->'price' "
+            + "FROM \"testCollection\" GROUP BY document->'item',document->'price' "
             + "HAVING (COUNT(DISTINCT document->>'quantity' ) <= ?) AND (CAST (document->'item' AS TEXT) = ?)",
         sql);
 
@@ -1109,13 +1114,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\", document->'price' AS \"price\" "
-            + "FROM testCollection GROUP BY document->'item',document->'price' "
+            + "FROM \"testCollection\" GROUP BY document->'item',document->'price' "
             + "HAVING (COUNT(DISTINCT document->>'quantity' ) <= ?) AND (CAST (document->'item' AS TEXT) IN (?, ?, ?, ?))",
         sql);
 
@@ -1153,12 +1158,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE (CAST (document->>'price' AS NUMERIC) <= ?) AND (document->>'item' IN (?, ?, ?, ?))",
         sql);
 
@@ -1189,12 +1194,12 @@ public class PostgresQueryParserTest {
             .build();
 
     final PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     final String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT document->'item' AS \"item\" "
-            + "FROM testCollection "
+            + "FROM \"testCollection\" "
             + "WHERE CAST (document->>'quantity' AS NUMERIC) * CAST (document->>'price' AS NUMERIC) > ? "
             + "ORDER BY document->'item' DESC NULLS LAST",
         sql);
@@ -1220,13 +1225,13 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "SELECT COUNT(DISTINCT document->>'quantity' ) AS \"qty_count\", "
             + "document->'item' AS \"item\" "
-            + "FROM testCollection WHERE CAST (document->>'price' AS NUMERIC) <= ? "
+            + "FROM \"testCollection\" WHERE CAST (document->>'price' AS NUMERIC) <= ? "
             + "GROUP BY document->'item'",
         sql);
 
@@ -1244,11 +1249,11 @@ public class PostgresQueryParserTest {
 
     final PostgresQueryParser postgresQueryParser =
         new PostgresQueryParser(
-            TEST_COLLECTION,
+            TEST_TABLE,
             PostgresQueryTransformer.transform(Query.builder().setFilter(filter).build()));
     final String sql = postgresQueryParser.parse();
 
-    assertEquals("SELECT * FROM testCollection WHERE id = ?", sql);
+    assertEquals("SELECT * FROM \"testCollection\" WHERE id = ?", sql);
 
     final Params params = postgresQueryParser.getParamsBuilder().build();
     assertEquals(1, params.getObjectParams().size());
@@ -1267,11 +1272,11 @@ public class PostgresQueryParserTest {
 
     final PostgresQueryParser postgresQueryParser =
         new PostgresQueryParser(
-            TEST_COLLECTION,
+            TEST_TABLE,
             PostgresQueryTransformer.transform(Query.builder().setFilter(filter).build()));
     final String sql = postgresQueryParser.parse();
 
-    assertEquals("SELECT * FROM testCollection WHERE (id = ?) OR (id = ?)", sql);
+    assertEquals("SELECT * FROM \"testCollection\" WHERE (id = ?) OR (id = ?)", sql);
 
     final Params params = postgresQueryParser.getParamsBuilder().build();
     assertEquals(2, params.getObjectParams().size());
@@ -1291,11 +1296,12 @@ public class PostgresQueryParserTest {
             .build();
     final PostgresQueryParser postgresQueryParser =
         new PostgresQueryParser(
-            TEST_COLLECTION,
+            TEST_TABLE,
             PostgresQueryTransformer.transform(Query.builder().setFilter(filter).build()));
     final String sql = postgresQueryParser.parse();
 
-    assertEquals("SELECT * FROM testCollection WHERE (id = ?) AND (document->>'item' != ?)", sql);
+    assertEquals(
+        "SELECT * FROM \"testCollection\" WHERE (id = ?) AND (document->>'item' != ?)", sql);
 
     final Params params = postgresQueryParser.getParamsBuilder().build();
     assertEquals(2, params.getObjectParams().size());
@@ -1314,9 +1320,9 @@ public class PostgresQueryParserTest {
                     ConstantExpression.of(new JSONDocument("\"a\""))))
             .build();
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
-    assertEquals("SELECT * FROM testCollection WHERE document->'sales' @> ?::jsonb", sql);
+    assertEquals("SELECT * FROM \"testCollection\" WHERE document->'sales' @> ?::jsonb", sql);
 
     Params params = postgresQueryParser.getParamsBuilder().build();
     assertEquals("[\"a\"]", params.getObjectParams().get(1));
@@ -1342,12 +1348,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection),\n"
+            + "table0 as (SELECT * from \"testCollection\"),\n"
             + "table1 as (SELECT * from table0 t0, jsonb_array_elements(document->'sales') p1(sales))\n"
             + "SELECT document->'item' AS \"item\", sales->'medium' AS \"sales_dot_medium\" FROM table1 WHERE sales->'medium' @> ?::jsonb",
         sql);
@@ -1377,12 +1383,12 @@ public class PostgresQueryParserTest {
             .build();
 
     PostgresQueryParser postgresQueryParser =
-        new PostgresQueryParser(TEST_COLLECTION, PostgresQueryTransformer.transform(query));
+        new PostgresQueryParser(TEST_TABLE, PostgresQueryTransformer.transform(query));
     String sql = postgresQueryParser.parse();
 
     assertEquals(
         "With \n"
-            + "table0 as (SELECT * from testCollection),\n"
+            + "table0 as (SELECT * from \"testCollection\"),\n"
             + "table1 as (SELECT * from table0 t0, jsonb_array_elements(document->'sales') p1(sales))\n"
             + "SELECT document->'item' AS \"item\", sales->'medium' AS \"sales_dot_medium\" FROM table1 WHERE sales->'medium' IS NULL OR NOT sales->'medium' @> ?::jsonb",
         sql);
@@ -1390,5 +1396,16 @@ public class PostgresQueryParserTest {
     Params params = postgresQueryParser.getParamsBuilder().build();
     assertEquals(1, params.getObjectParams().size());
     assertEquals("[{\"type\":\"retail\",\"volume\":500}]", params.getObjectParams().get(1));
+  }
+
+  @Test
+  void testCollectionInOtherSchema() {
+    PostgresQueryParser postgresQueryParser =
+        new PostgresQueryParser(
+            PostgresTableIdentifier.parse("test_schema.test_table.with_a_dot"),
+            PostgresQueryTransformer.transform(Query.builder().build()));
+
+    assertEquals(
+        "SELECT * FROM test_schema.\"test_table.with_a_dot\"", postgresQueryParser.parse());
   }
 }

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2023-10-30Z">
+  <suppress until="2023-12-31Z">
     <notes><![CDATA[
-  file name: jackson-databind-2.15.1.jar
-  ]]></notes>
-    <!-- No fix available yet (Disputed) -->
-    <!-- Transitive from other dependencies -->
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <cve>CVE-2023-35116</cve>
+   Doesn't appear to be a real vulnerability, jackson maintainers discuss at https://github.com/FasterXML/jackson-databind/issues/3973
+   Revisit when suppression expires
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$
+    </packageUrl>
+    <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
   </suppress>
   <suppress>
     <notes><![CDATA[


### PR DESCRIPTION
Add postgres support for a table named like "x.y.z" - which is valid in mongo, but not postgres. This change converts the first segment to be the schema name, and quotes everything after (uniformly, whether needed or not)