### PR TITLE
fix: reorder unwind stages

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
@@ -1,7 +1,7 @@
 package org.hypertrace.core.documentstore.mongo.query;
 
 import static java.lang.Long.parseLong;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.function.Predicate.not;
 import static org.hypertrace.core.documentstore.mongo.clause.MongoCountClauseSupplier.COUNT_ALIAS;
@@ -25,6 +25,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCursor;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,11 +53,9 @@ public class MongoQueryExecutor {
               query -> singleton(getSkipClause(query)),
               query -> singleton(getLimitClause(query)));
 
-  private static Collection<BasicDBObject> getPostUnwindingFilterClause(
+  private static Set<BasicDBObject> getPostUnwindingFilterClause(
       final Query query, final List<BasicDBObject> fromClauses) {
-    return fromClauses.isEmpty()
-        ? emptyList()
-        : singleton(getFilterClause(query, Query::getFilter));
+    return fromClauses.isEmpty() ? emptySet() : singleton(getFilterClause(query, Query::getFilter));
   }
 
   private final com.mongodb.client.MongoCollection<BasicDBObject> collection;

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
@@ -40,8 +40,8 @@ public class MongoQueryExecutor {
   private static final List<Function<Query, Collection<BasicDBObject>>>
       AGGREGATE_PIPELINE_FUNCTIONS =
           List.of(
-              query -> singleton(getFilterClause(query, Query::getFilter)),
               MongoFromTypeExpressionParser::getFromClauses,
+              query -> singleton(getFilterClause(query, Query::getFilter)),
               query -> singleton(getGroupClause(query)),
               query -> singleton(getProjectClause(query)),
               query -> singleton(getFilterClause(query, Query::getAggregationFilter)),

--- a/document-store/src/test/resources/mongo/pipeline/unwind_and_group.json
+++ b/document-store/src/test/resources/mongo/pipeline/unwind_and_group.json
@@ -1,12 +1,5 @@
 [
   {
-    "$match": {
-      "class": {
-        "$lte": 10
-      }
-    }
-  },
-  {
     "$unwind": {
       "path": "$class.students",
       "preserveNullAndEmptyArrays": true
@@ -16,6 +9,13 @@
     "$unwind": {
       "path": "$class.students.courses",
       "preserveNullAndEmptyArrays": true
+    }
+  },
+  {
+    "$match": {
+      "class": {
+        "$lte": 10
+      }
     }
   },
   {

--- a/document-store/src/test/resources/mongo/pipeline/unwind_and_group.json
+++ b/document-store/src/test/resources/mongo/pipeline/unwind_and_group.json
@@ -1,5 +1,12 @@
 [
   {
+    "$match": {
+      "class": {
+        "$lte": 10
+      }
+    }
+  },
+  {
     "$unwind": {
       "path": "$class.students",
       "preserveNullAndEmptyArrays": true


### PR DESCRIPTION
This PR re-orders unwind stages of the mongo aggregation pipeline to the top.
