### PR TITLE
MongoDB read path enhancements

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/mongo/MongoConnectionConfig.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/mongo/MongoConnectionConfig.java
@@ -59,7 +59,10 @@ public class MongoConnectionConfig extends ConnectionConfig {
 
   public MongoClientSettings toSettings() {
     final MongoClientSettings.Builder settingsBuilder =
-        MongoClientSettings.builder().applicationName(applicationName()).retryWrites(true);
+        MongoClientSettings.builder()
+            .applicationName(applicationName())
+            .retryWrites(true)
+            .retryReads(true);
 
     applyClusterSettings(settingsBuilder);
     applyConnectionPoolSettings(settingsBuilder);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/MongoCollection.java
@@ -731,7 +731,15 @@ public class MongoCollection implements Collection {
 
     @Override
     public boolean hasNext() {
-      boolean hasNext = !closed && cursor.hasNext();
+      boolean hasNext;
+
+      try {
+        hasNext = !closed && cursor.hasNext();
+      } catch (final Exception e) {
+        close();
+        throw e;
+      }
+
       if (!hasNext) {
         close();
       }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/postgres/PostgresCollectionTest.java
@@ -338,6 +338,7 @@ class PostgresCollectionTest {
     when(mockConnection.prepareStatement(selectQuery)).thenReturn(mockSelectPreparedStatement);
     when(mockSelectPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(false);
+    when(mockResultSet.isClosed()).thenReturn(false, true);
 
     final Optional<Document> oldDocument =
         postgresCollection.update(
@@ -492,6 +493,7 @@ class PostgresCollectionTest {
     when(mockSelectPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true).thenReturn(false);
     when(mockResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+    when(mockResultSet.isClosed()).thenReturn(false, true);
     when(mockResultSetMetaData.getColumnCount()).thenReturn(4);
     mockResultSetMetadata();
 
@@ -660,6 +662,7 @@ class PostgresCollectionTest {
     when(mockConnection.prepareStatement(selectQuery)).thenReturn(mockSelectPreparedStatement);
     when(mockSelectPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(false);
+    when(mockResultSet.isClosed()).thenReturn(false, true);
 
     final String updateQuery =
         String.format(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ org-mockito = "5.2.0"
 org-testcontainers = "1.17.6"
 
 [libraries]
-com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.15.1" }
+com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.16.1" }
 com-github-java-json-tools-json-patch = { module = "com.github.java-json-tools:json-patch", version = "1.13" }
 com-google-guava = { module = "com.google.guava:guava", version = "32.0.1-jre" }
 com-typesafe-config = { module = "com.typesafe:config", version = "1.4.2" }


### PR DESCRIPTION
1. Enable read-retries for Mongo
2. Close Mongo connection on exceptions in cursor.hasNext()
3. Close Postgres connections on reaching the end of the result set or an exception occurs
