### PR TITLE
Enable disk usage for aggregations on MongoDB

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,11 +21,12 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           name: unit test reports
           fail_ci_if_error: true
           flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Integration test
         uses: hypertrace/github-actions/gradle@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,11 +34,12 @@ jobs:
           args: jacocoIntegrationTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           name: integration test reports
           fail_ci_if_error: true
           flags: integration
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: copy test reports
         uses: hypertrace/github-actions/gradle@main

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/MongoQueryExecutor.java
@@ -130,7 +130,8 @@ public class MongoQueryExecutor {
     logPipeline(pipeline);
 
     try {
-      final AggregateIterable<BasicDBObject> iterable = collection.aggregate(pipeline);
+      final AggregateIterable<BasicDBObject> iterable =
+          collection.aggregate(pipeline).allowDiskUse(true);
       return iterable.cursor();
     } catch (final MongoCommandException e) {
       log.error("Execution failed for query: {}. Aggregation Pipeline: {}", query, pipeline);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoCollectionTest.java
@@ -378,6 +378,7 @@ public class MongoCollectionTest {
 
       when(mockClock.millis()).thenReturn(1660721309000L);
       when(collection.aggregate(anyList())).thenReturn(mockIterable);
+      when(mockIterable.allowDiskUse(true)).thenReturn(mockIterable);
       when(mockIterable.cursor()).thenReturn(mockCursor);
       when(mockCursor.hasNext()).thenReturn(true).thenReturn(false);
       when(mockCursor.next()).thenReturn(response);

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/mongo/MongoQueryExecutorTest.java
@@ -96,6 +96,7 @@ class MongoQueryExecutorTest {
     when(iterable.sort(any(BasicDBObject.class))).thenReturn(iterable);
 
     when(iterable.cursor()).thenReturn(cursor);
+    when(aggIterable.allowDiskUse(true)).thenReturn(aggIterable);
     when(aggIterable.cursor()).thenReturn(cursor);
   }
 
@@ -522,6 +523,7 @@ class MongoQueryExecutorTest {
     executor.aggregate(query);
     verify(collection).getNamespace();
     verify(collection).aggregate(pipeline);
+    verify(aggIterable).allowDiskUse(true);
     verify(aggIterable).cursor();
   }
 


### PR DESCRIPTION
Some of the aggregation queries could fail because of memory limits per aggregation pipeline on MongoDB. To avoid such issue, this PR allows disk usage so that the queries that couldn't fit in the memory limits can leverage the disk usage. 