### PR TITLE
fix: correctly get string label value for each jsonNode types

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/metric/BaseDocStoreMetricProviderImpl.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/metric/BaseDocStoreMetricProviderImpl.java
@@ -101,7 +101,9 @@ public abstract class BaseDocStoreMetricProviderImpl implements DocStoreMetricPr
                         jsonNodeMap.entrySet().iterator(), Spliterator.ORDERED),
                     false)
                 .filter(entry -> !VALUE_KEY.equals(entry.getKey()))
-                .collect(toUnmodifiableMap(Entry::getKey, entry -> entry.getValue().textValue()));
+                .collect(
+                    toUnmodifiableMap(
+                        Entry::getKey, entry -> getStringLabelValue(entry.getValue())));
 
         final DocStoreMetric metric =
             DocStoreMetric.builder()
@@ -117,6 +119,19 @@ public abstract class BaseDocStoreMetricProviderImpl implements DocStoreMetricPr
     } catch (final Exception e) {
       log.error("Unable to report metric: {}", customMetricConfig, e);
       return emptyList();
+    }
+  }
+
+  private String getStringLabelValue(JsonNode jsonNode) {
+    switch (jsonNode.getNodeType()) {
+      case STRING:
+        return jsonNode.textValue();
+      case NUMBER:
+      case BOOLEAN:
+        return String.valueOf(jsonNode.numberValue());
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported JSON node type: %s", jsonNode.getNodeType()));
     }
   }
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/metric/BaseDocStoreMetricProviderImpl.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/metric/BaseDocStoreMetricProviderImpl.java
@@ -127,8 +127,9 @@ public abstract class BaseDocStoreMetricProviderImpl implements DocStoreMetricPr
       case STRING:
         return jsonNode.textValue();
       case NUMBER:
-      case BOOLEAN:
         return String.valueOf(jsonNode.numberValue());
+      case BOOLEAN:
+        return String.valueOf(jsonNode.booleanValue());
       default:
         throw new IllegalArgumentException(
             String.format("Unsupported JSON node type: %s", jsonNode.getNodeType()));


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
