### PR TITLE
added hiphen in subdocpath

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
@@ -19,7 +19,7 @@ public class SubDocument {
 
   private static final Set<String> IMPLICIT_PATHS = Set.of(CREATED_TIME, LAST_UPDATED_TIME);
   private static final Pattern ALLOWED_CHARACTERS =
-      Pattern.compile("^[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)*$");
+      Pattern.compile("^[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)*$");
 
   String path;
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/subdoc/SubDocument.java
@@ -19,7 +19,7 @@ public class SubDocument {
 
   private static final Set<String> IMPLICIT_PATHS = Set.of(CREATED_TIME, LAST_UPDATED_TIME);
   private static final Pattern ALLOWED_CHARACTERS =
-      Pattern.compile("^[a-zA-Z0-9_]+(.[a-zA-Z0-9_]+)*$");
+      Pattern.compile("^[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)*$");
 
   String path;
 


### PR DESCRIPTION
## Description
This will allow subdocpath to have "-" in it. It will be used in cases where we want to add negative values to a map to list.


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
