### PR TITLE
Add realtime freshness to bulk update query

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/update/MongoUpdateExecutor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/update/MongoUpdateExecutor.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.documentstore.mongo.update;
 
+import static org.hypertrace.core.documentstore.model.options.DataFreshness.REALTIME_FRESHNESS;
 import static org.hypertrace.core.documentstore.model.options.ReturnDocumentType.NONE;
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.getReturnDocument;
 import static org.hypertrace.core.documentstore.mongo.query.parser.MongoFilterTypeExpressionParser.getFilter;
@@ -19,6 +20,7 @@ import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.commons.CommonUpdateValidator;
 import org.hypertrace.core.documentstore.commons.UpdateValidator;
 import org.hypertrace.core.documentstore.model.config.ConnectionConfig;
+import org.hypertrace.core.documentstore.model.options.QueryOptions;
 import org.hypertrace.core.documentstore.model.options.ReturnDocumentType;
 import org.hypertrace.core.documentstore.model.options.UpdateOptions;
 import org.hypertrace.core.documentstore.model.options.UpdateOptions.MissingDocumentStrategy;
@@ -106,13 +108,17 @@ public class MongoUpdateExecutor {
 
     switch (returnDocumentType) {
       case BEFORE_UPDATE:
-        cursor = queryExecutor.aggregate(query);
+        cursor =
+            queryExecutor.aggregate(
+                query, QueryOptions.builder().dataFreshness(REALTIME_FRESHNESS).build());
         logAndUpdate(filter, updateObject, mongoUpdateOptions);
         return Optional.of(cursor);
 
       case AFTER_UPDATE:
         logAndUpdate(filter, updateObject, mongoUpdateOptions);
-        cursor = queryExecutor.aggregate(query);
+        cursor =
+            queryExecutor.aggregate(
+                query, QueryOptions.builder().dataFreshness(REALTIME_FRESHNESS).build());
         return Optional.of(cursor);
 
       case NONE:


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
