### PR TITLE
[295] Make maxIdle and minIdle configurable

### DIFF
--- a/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPoolIntegrationTest.java
+++ b/document-store/src/integrationTest/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPoolIntegrationTest.java
@@ -74,10 +74,13 @@ public class PostgresConnectionPoolIntegrationTest {
 
   @Test
   public void testGetTransactionalConnection() throws SQLException {
-    final PostgresConnectionConfig config = createTestConfig();
+    final PostgresConnectionConfig config = createTestConfig(1);
     final PostgresConnectionPool pool = new PostgresConnectionPool(config);
 
+    Connection transactionalConnection;
+
     try (final Connection connection = pool.getTransactionalConnection()) {
+      transactionalConnection = connection;
       assertNotNull(connection);
       assertFalse(
           connection.getAutoCommit(), "Transactional connection should have autoCommit=false");
@@ -92,6 +95,12 @@ public class PostgresConnectionPoolIntegrationTest {
 
       // Verify we can commit manually
       connection.commit();
+    }
+
+    try (final Connection connection = pool.getConnection()) {
+      // validate that after the connection was returned back to the pool earlier, auto-commit was
+      // reset successfully
+      assertTrue(connection.getAutoCommit());
     }
 
     pool.close();
@@ -266,6 +275,23 @@ public class PostgresConnectionPoolIntegrationTest {
             .connectionPoolConfig(
                 ConnectionPoolConfig.builder()
                     .maxConnections(5)
+                    .connectionAccessTimeout(Duration.ofSeconds(10))
+                    .connectionSurrenderTimeout(Duration.ofSeconds(30))
+                    .build())
+            .build();
+  }
+
+  private static PostgresConnectionConfig createTestConfig(int maxConnections) {
+    return (PostgresConnectionConfig)
+        ConnectionConfig.builder()
+            .type(DatabaseType.POSTGRES)
+            .addEndpoint(Endpoint.builder().host(host).port(port).build())
+            .database("postgres")
+            .credentials(
+                ConnectionCredentials.builder().username("postgres").password("postgres").build())
+            .connectionPoolConfig(
+                ConnectionPoolConfig.builder()
+                    .maxConnections(maxConnections)
                     .connectionAccessTimeout(Duration.ofSeconds(10))
                     .connectionSurrenderTimeout(Duration.ofSeconds(30))
                     .build())

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
@@ -14,13 +14,14 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConnectionPoolConfig {
+
   @NonNull @Nonnegative @Builder.Default Integer maxConnections = 16;
 
-  // max idle connections as a percentage of max connections; -1 means pin to maxConnections
-  @NonNull @Builder.Default Integer maxIdlePercent = -1;
+  // max idle connections as a percentage of max connections; 20% by default
+  @NonNull @Builder.Default Integer maxIdlePercent = 20;
 
-  // min idle connections as a percentage of max connections; -1 means pin to maxConnections
-  @NonNull @Builder.Default Integer minIdlePercent = -1;
+  // min idle connections as a percentage of max connections; 10% by default
+  @NonNull @Builder.Default Integer minIdlePercent = 10;
 
   // Time duration to wait for obtaining a connection from the pool
   @NonNull @Builder.Default Duration connectionAccessTimeout = Duration.ofSeconds(10);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
@@ -16,6 +16,12 @@ import lombok.experimental.Accessors;
 public class ConnectionPoolConfig {
   @NonNull @Nonnegative @Builder.Default Integer maxConnections = 16;
 
+  // max idle connections as a percentage of max connections; -1 means pin to maxConnections
+  @NonNull @Builder.Default Integer maxIdlePercent = -1;
+
+  // min idle connections as a percentage of max connections; -1 means pin to maxConnections
+  @NonNull @Builder.Default Integer minIdlePercent = -1;
+
   // Time duration to wait for obtaining a connection from the pool
   @NonNull @Builder.Default Duration connectionAccessTimeout = Duration.ofSeconds(10);
 

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
@@ -32,6 +32,8 @@ public class TypesafeConfigDatastoreConfigExtractor {
   private static final String DEFAULT_MAX_POOL_SIZE_KEY = "maxPoolSize";
   private static final String DEFAULT_CONNECTION_ACCESS_TIMEOUT_KEY = "connectionAccessTimeout";
   private static final String DEFAULT_CONNECTION_IDLE_TIME_KEY = "connectionIdleTime";
+  private static final String DEFAULT_MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
+  private static final String DEFAULT_MIN_IDLE_PERCENT_KEY = "minIdelPercent";
   private static final String DEFAULT_AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DEFAULT_DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String DEFAULT_QUERY_TIMEOUT_KEY = "queryTimeout";
@@ -84,6 +86,8 @@ public class TypesafeConfigDatastoreConfigExtractor {
         .poolMaxConnectionsKey(DEFAULT_MAX_POOL_SIZE_KEY)
         .poolConnectionAccessTimeoutKey(DEFAULT_CONNECTION_ACCESS_TIMEOUT_KEY)
         .poolConnectionSurrenderTimeoutKey(DEFAULT_CONNECTION_IDLE_TIME_KEY)
+        .poolMaxIdlePercentKey(DEFAULT_MAX_IDLE_PERCENT_KEY)
+        .poolMinIdlePercentKey(DEFAULT_MIN_IDLE_PERCENT_KEY)
         .aggregationPipelineMode(DEFAULT_AGGREGATION_PIPELINE_MODE_KEY)
         .dataFreshnessKey(DEFAULT_DATA_FRESHNESS_KEY)
         .queryTimeoutKey(DEFAULT_QUERY_TIMEOUT_KEY)
@@ -224,6 +228,20 @@ public class TypesafeConfigDatastoreConfigExtractor {
       @NonNull final String key) {
     if (config.hasPath(key)) {
       connectionPoolConfigBuilder.connectionSurrenderTimeout(config.getDuration(key));
+    }
+    return this;
+  }
+
+  public TypesafeConfigDatastoreConfigExtractor poolMaxIdlePercentKey(@NonNull final String key) {
+    if (config.hasPath(key)) {
+      connectionPoolConfigBuilder.maxIdlePercent(config.getInt(key));
+    }
+    return this;
+  }
+
+  public TypesafeConfigDatastoreConfigExtractor poolMinIdlePercentKey(@NonNull final String key) {
+    if (config.hasPath(key)) {
+      connectionPoolConfigBuilder.minIdlePercent(config.getInt(key));
     }
     return this;
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
@@ -33,7 +33,7 @@ public class TypesafeConfigDatastoreConfigExtractor {
   private static final String DEFAULT_CONNECTION_ACCESS_TIMEOUT_KEY = "connectionAccessTimeout";
   private static final String DEFAULT_CONNECTION_IDLE_TIME_KEY = "connectionIdleTime";
   private static final String DEFAULT_MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
-  private static final String DEFAULT_MIN_IDLE_PERCENT_KEY = "minIdelPercent";
+  private static final String DEFAULT_MIN_IDLE_PERCENT_KEY = "minIdlePercent";
   private static final String DEFAULT_AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DEFAULT_DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String DEFAULT_QUERY_TIMEOUT_KEY = "queryTimeout";

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
@@ -22,48 +22,43 @@ class PostgresConnectionPool {
   private static final String VALIDATION_QUERY = "SELECT 1";
   private static final Duration VALIDATION_QUERY_TIMEOUT = Duration.ofSeconds(5);
 
-  // data source for pools with auto-commits enabled
-  private final PoolingDataSource<PoolableConnection> regularDataSource;
-  // data source for pools with auto-commits disabled. This is used for transactional operations
-  // that manage their own commit logic
-  private final PoolingDataSource<PoolableConnection> transactionalDataSource;
+  // Single pool with autoCommit=true by default. Transactional connections flip autoCommit
+  // to false on borrow; DBCP2 resets it back when the connection is returned to the pool.
+  private final PoolingDataSource<PoolableConnection> dataSource;
 
   PostgresConnectionPool(final PostgresConnectionConfig config) {
-    this.regularDataSource = createPooledDataSource(config, true);
-    this.transactionalDataSource = createPooledDataSource(config, false);
+    this.dataSource = createPooledDataSource(config);
   }
 
   /**
-   * Get a connection from the regular pool with autoCommit=true. Use for read-only queries that
-   * don't need manual transaction management.
+   * Get a connection with autoCommit=true (pool default). Use for simple queries that don't need
+   * manual transaction management.
    */
   public Connection getConnection() throws SQLException {
-    return regularDataSource.getConnection();
+    return dataSource.getConnection();
   }
 
   /**
-   * Get a connection from the transactional pool with autoCommit=false. Use for operations that
-   * require manual transaction management (commit/rollback).
+   * Get a connection with autoCommit=false for manual transaction management (commit/rollback).
+   * When the connection is closed/returned to the pool, DBCP2 automatically resets autoCommit back
+   * to the pool default (true).
    */
   public Connection getTransactionalConnection() throws SQLException {
-    return transactionalDataSource.getConnection();
+    Connection conn = dataSource.getConnection();
+    conn.setAutoCommit(false);
+    return conn;
   }
 
   public void close() {
     try {
-      regularDataSource.close();
+      dataSource.close();
     } catch (final SQLException e) {
-      log.warn("Unable to close regular Postgres connection pool", e);
-    }
-    try {
-      transactionalDataSource.close();
-    } catch (final SQLException e) {
-      log.warn("Unable to close transactional Postgres connection pool", e);
+      log.warn("Unable to close Postgres connection pool", e);
     }
   }
 
   private PoolingDataSource<PoolableConnection> createPooledDataSource(
-      final PostgresConnectionConfig config, final boolean autoCommit) {
+      final PostgresConnectionConfig config) {
     final ConnectionFactory connectionFactory =
         new DriverManagerConnectionFactory(config.toConnectionString(), config.buildProperties());
     final PoolableConnectionFactory poolableConnectionFactory =
@@ -73,7 +68,7 @@ class PostgresConnectionPool {
 
     final ConnectionPoolConfig poolConfig = config.connectionPoolConfig();
     setPoolProperties(connectionPool, poolConfig);
-    setFactoryProperties(poolableConnectionFactory, connectionPool, autoCommit);
+    setFactoryProperties(poolableConnectionFactory, connectionPool);
 
     return new PoolingDataSource<>(connectionPool);
   }
@@ -100,13 +95,12 @@ class PostgresConnectionPool {
 
   private void setFactoryProperties(
       PoolableConnectionFactory poolableConnectionFactory,
-      GenericObjectPool<PoolableConnection> connectionPool,
-      boolean autoCommit) {
+      GenericObjectPool<PoolableConnection> connectionPool) {
     poolableConnectionFactory.setPool(connectionPool);
     poolableConnectionFactory.setValidationQuery(VALIDATION_QUERY);
     poolableConnectionFactory.setValidationQueryTimeout((int) VALIDATION_QUERY_TIMEOUT.toSeconds());
     poolableConnectionFactory.setDefaultReadOnly(false);
-    poolableConnectionFactory.setDefaultAutoCommit(autoCommit);
+    poolableConnectionFactory.setDefaultAutoCommit(true);
     poolableConnectionFactory.setDefaultTransactionIsolation(TRANSACTION_READ_COMMITTED);
     poolableConnectionFactory.setPoolStatements(false);
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
@@ -90,7 +90,7 @@ class PostgresConnectionPool {
     connectionPool.setMaxWaitMillis(poolConfig.connectionAccessTimeout().toMillis());
     connectionPool.setAbandonedConfig(abandonedConfig);
     log.debug(
-        "Connection pool properties - maxTotal: {}, maxIdle: {}, minIdle: {}, maxWaitMillis: {}, connectionSurrenderTimeout: {}",
+        "Postgres connection pool properties - maxTotal: {}, maxIdle: {}, minIdle: {}, maxWaitMillis: {}, connectionSurrenderTimeout: {}",
         connectionPool.getMaxTotal(),
         connectionPool.getMaxIdle(),
         connectionPool.getMinIdle(),

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
@@ -84,13 +84,18 @@ class PostgresConnectionPool {
     final AbandonedConfig abandonedConfig = getAbandonedConfig(poolConfig);
     final int maxConnections = poolConfig.maxConnections();
     connectionPool.setMaxTotal(maxConnections);
-    // max idle connections are 20% of max connections
-    connectionPool.setMaxIdle(getPercentOf(20, maxConnections));
-    // min idle connections are 10% of max connections
-    connectionPool.setMinIdle(getPercentOf(10, maxConnections));
+    connectionPool.setMaxIdle(getIdleCount(poolConfig.maxIdlePercent(), maxConnections));
+    connectionPool.setMinIdle(getIdleCount(poolConfig.minIdlePercent(), maxConnections));
     connectionPool.setBlockWhenExhausted(true);
     connectionPool.setMaxWaitMillis(poolConfig.connectionAccessTimeout().toMillis());
     connectionPool.setAbandonedConfig(abandonedConfig);
+    log.debug(
+        "Connection pool properties - maxTotal: {}, maxIdle: {}, minIdle: {}, maxWaitMillis: {}, connectionSurrenderTimeout: {}",
+        connectionPool.getMaxTotal(),
+        connectionPool.getMaxIdle(),
+        connectionPool.getMinIdle(),
+        connectionPool.getMaxWaitMillis(),
+        poolConfig.connectionSurrenderTimeout());
   }
 
   private void setFactoryProperties(
@@ -115,7 +120,10 @@ class PostgresConnectionPool {
     return abandonedConfig;
   }
 
-  private int getPercentOf(final int percent, final int maxConnections) {
+  private int getIdleCount(final int percent, final int maxConnections) {
+    if (percent < 0) {
+      return maxConnections;
+    }
     final int value = (maxConnections * percent) / 100;
     return Math.max(value, 1);
   }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
@@ -35,7 +35,7 @@ class TypesafeConfigDatastoreConfigExtractorTest {
   private static final String CONNECTION_ACCESS_TIMEOUT_KEY = "connectionAccessTimeout";
   private static final String CONNECTION_SURRENDER_TIMEOUT_KEY = "connectionSurrenderTimeout";
   private static final String MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
-  private static final String MIN_IDLE_PERCENT_KEY = "minIdelPercent";
+  private static final String MIN_IDLE_PERCENT_KEY = "minIdlePercent";
   private static final String AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String QUERY_TIMEOUT_KEY = "queryTimeout";

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
@@ -444,8 +444,8 @@ class TypesafeConfigDatastoreConfigExtractorTest {
                 .connectionConfig();
 
     final ConnectionPoolConfig poolConfig = config.connectionPoolConfig();
-    assertEquals(-1, poolConfig.maxIdlePercent());
-    assertEquals(-1, poolConfig.minIdlePercent());
+    assertEquals(20, poolConfig.maxIdlePercent());
+    assertEquals(10, poolConfig.minIdlePercent());
   }
 
   @Test

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
@@ -34,6 +34,8 @@ class TypesafeConfigDatastoreConfigExtractorTest {
   private static final String MAX_CONNECTIONS_KEY = "maxConnectionsKey";
   private static final String CONNECTION_ACCESS_TIMEOUT_KEY = "connectionAccessTimeout";
   private static final String CONNECTION_SURRENDER_TIMEOUT_KEY = "connectionSurrenderTimeout";
+  private static final String MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
+  private static final String MIN_IDLE_PERCENT_KEY = "minIdelPercent";
   private static final String AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String QUERY_TIMEOUT_KEY = "queryTimeout";
@@ -52,6 +54,8 @@ class TypesafeConfigDatastoreConfigExtractorTest {
   private static final int maxConnections = 7;
   private static final Duration accessTimeout = Duration.ofSeconds(67);
   private static final Duration surrenderTimeout = Duration.ofSeconds(56);
+  private static final int maxIdlePercent = 30;
+  private static final int minIdlePercent = 15;
   private static final AggregatePipelineMode aggregatePipelineMode = SORT_OPTIMIZED_IF_POSSIBLE;
   private static final DataFreshness dataFreshness = NEAR_REALTIME_FRESHNESS;
   private static final Duration queryTimeout = Duration.ofSeconds(45);
@@ -421,6 +425,66 @@ class TypesafeConfigDatastoreConfigExtractorTest {
     assertTrue(collectionConfig.get().getTimestampFields().isPresent());
     assertFalse(collectionConfig.get().getTimestampFields().get().getCreated().isPresent());
     assertFalse(collectionConfig.get().getTimestampFields().get().getLastUpdated().isPresent());
+  }
+
+  @Test
+  void testDefaultIdlePercentValues() {
+    final PostgresConnectionConfig config =
+        (PostgresConnectionConfig)
+            TypesafeConfigDatastoreConfigExtractor.from(buildConfigMap(), DatabaseType.POSTGRES)
+                .hostKey(HOST_KEY)
+                .portKey(PORT_KEY)
+                .databaseKey(DATABASE_KEY)
+                .usernameKey(USER_KEY)
+                .passwordKey(PASSWORD_KEY)
+                .poolMaxConnectionsKey(MAX_CONNECTIONS_KEY)
+                .poolConnectionAccessTimeoutKey(CONNECTION_ACCESS_TIMEOUT_KEY)
+                .poolConnectionSurrenderTimeoutKey(CONNECTION_SURRENDER_TIMEOUT_KEY)
+                .extract()
+                .connectionConfig();
+
+    final ConnectionPoolConfig poolConfig = config.connectionPoolConfig();
+    assertEquals(-1, poolConfig.maxIdlePercent());
+    assertEquals(-1, poolConfig.minIdlePercent());
+  }
+
+  @Test
+  void testCustomIdlePercentValues() {
+    final PostgresConnectionConfig config =
+        (PostgresConnectionConfig)
+            TypesafeConfigDatastoreConfigExtractor.from(
+                    buildConfigMapWithIdlePercent(), DatabaseType.POSTGRES)
+                .hostKey(HOST_KEY)
+                .portKey(PORT_KEY)
+                .databaseKey(DATABASE_KEY)
+                .usernameKey(USER_KEY)
+                .passwordKey(PASSWORD_KEY)
+                .poolMaxConnectionsKey(MAX_CONNECTIONS_KEY)
+                .poolConnectionAccessTimeoutKey(CONNECTION_ACCESS_TIMEOUT_KEY)
+                .poolConnectionSurrenderTimeoutKey(CONNECTION_SURRENDER_TIMEOUT_KEY)
+                .poolMaxIdlePercentKey(MAX_IDLE_PERCENT_KEY)
+                .poolMinIdlePercentKey(MIN_IDLE_PERCENT_KEY)
+                .extract()
+                .connectionConfig();
+
+    final ConnectionPoolConfig poolConfig = config.connectionPoolConfig();
+    assertEquals(maxIdlePercent, poolConfig.maxIdlePercent());
+    assertEquals(minIdlePercent, poolConfig.minIdlePercent());
+  }
+
+  private Config buildConfigMapWithIdlePercent() {
+    return ConfigFactory.parseMap(
+        Map.ofEntries(
+            entry(HOST_KEY, host),
+            entry(PORT_KEY, port),
+            entry(DATABASE_KEY, database),
+            entry(USER_KEY, user),
+            entry(PASSWORD_KEY, password),
+            entry(MAX_CONNECTIONS_KEY, maxConnections),
+            entry(CONNECTION_ACCESS_TIMEOUT_KEY, accessTimeout),
+            entry(CONNECTION_SURRENDER_TIMEOUT_KEY, surrenderTimeout),
+            entry(MAX_IDLE_PERCENT_KEY, maxIdlePercent),
+            entry(MIN_IDLE_PERCENT_KEY, minIdlePercent)));
   }
 
   private Config buildConfigMap() {


### PR DESCRIPTION
## Description
Ref: https://github.com/hypertrace/document-store/issues/295

In addition to the config changes, this PR also gets rid of the dedicated transactional connection pool and uses the regular pool with `autoCommit=false`, whenever a transactional connection is requested. Whenever such a connection is returned to the pool, DBCP2 resets its `autoCommit` state to `true`. This approach basically cuts the number of connections to half. [Ref](https://commons.apache.org/proper/commons-dbcp/apidocs/org/apache/commons/dbcp2/PoolableConnectionFactory.html#setAutoCommitOnReturn(boolean)).

This PR also gets rid of the transactional datasource

### Testing
- [x] Added UT.
- [x] Tested this in an actual env
- [x] Added integration test to validate that when a transactional connection is returned to the pool, DBCP2 resets its `autoCommit` state to `true`.

Log from e2e testing:
```
026-04-28 06:48:04.552 [main] DEBUG o.h.c.d.p.PostgresConnectionPool - Connection pool properties - maxTotal: 32, maxIdle: 32, minIdle: 32, maxWaitMillis: 10000, connectionSurrenderTimeout: PT5M
2026-04-28 06:48:04.554 [main] DEBUG o.h.c.d.p.PostgresConnectionPool - Connection pool properties - maxTotal: 32, maxIdle: 32, minIdle: 32, maxWaitMillis: 10000, connectionSurrenderTimeout: PT5M
```

### Checklist
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
