### PR TITLE
[290] Fix query shape for FlatPostgresCollection upsert and createOrReplace

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -392,7 +392,7 @@ public class FlatPostgresCollection extends PostgresCollection {
       // Build the bulk upsert SQL with all columns
       // Use COALESCE to preserve existing values when a document doesn't have a column
       List<String> columnList = new ArrayList<>(allColumns);
-      String sql = buildMergeUpsertSql(columnList, quotedPkColumn, false, true);
+      String sql = buildMergeUpsertSql(columnList, quotedPkColumn, false);
       LOGGER.debug("Bulk upsert SQL: {}", sql);
 
       try (Connection conn = client.getPooledConnection();
@@ -597,24 +597,6 @@ public class FlatPostgresCollection extends PostgresCollection {
    */
   private String buildMergeUpsertSql(
       List<String> columns, String pkColumn, boolean includeReturning) {
-    return buildMergeUpsertSql(columns, pkColumn, includeReturning, false);
-  }
-
-  /**
-   * Builds a PostgreSQL upsert SQL statement with merge semantics.
-   *
-   * <p>Generates: INSERT ... ON CONFLICT DO UPDATE SET col = EXCLUDED.col for each column. Only
-   * columns in the provided list are updated on conflict (merge behavior).
-   *
-   * @param columns List of quoted column names to include
-   * @param pkColumn The quoted primary key column name
-   * @param includeReturning If true, adds RETURNING clause to detect insert vs update
-   * @param useCoalesce If true, uses COALESCE(EXCLUDED.col, table.col) to preserve existing values
-   *     when the new value is NULL
-   * @return The upsert SQL statement
-   */
-  private String buildMergeUpsertSql(
-      List<String> columns, String pkColumn, boolean includeReturning, boolean useCoalesce) {
     String columnList = String.join(", ", columns);
     String placeholders = String.join(", ", columns.stream().map(c -> "?").toArray(String[]::new));
 
@@ -632,20 +614,8 @@ public class FlatPostgresCollection extends PostgresCollection {
             .filter(col -> !col.equals(pkColumn))
             .filter(col -> !col.equals(quotedCreatedTs))
             .map(
-                col -> {
-                  if (useCoalesce) {
-                    return col
-                        + " = COALESCE(EXCLUDED."
-                        + col
-                        + ", "
-                        + tableIdentifier
-                        + "."
-                        + col
-                        + ")";
-                  } else {
-                    return col + " = EXCLUDED." + col;
-                  }
-                })
+                col ->
+                    col + " = COALESCE(EXCLUDED." + col + ", " + tableIdentifier + "." + col + ")")
             .collect(Collectors.joining(", "));
 
     String sql =
@@ -1515,7 +1485,7 @@ public class FlatPostgresCollection extends PostgresCollection {
       String sql = buildUpsertSql(docColumns, quotedPkColumn);
       LOGGER.debug("Upsert (merge) SQL: {}", sql);
 
-      return executeUpsert(sql, parsed);
+      return executeUpsert(sql, docColumns, parsed);
 
     } catch (PSQLException e) {
       return handlePSQLExceptionForUpsert(e, key, document, tableName, isRetry);
@@ -1528,29 +1498,31 @@ public class FlatPostgresCollection extends PostgresCollection {
   /**
    * Builds a PostgreSQL upsert SQL statement with merge semantics.
    *
-   * <p>This method constructs an atomic upsert query that:
+   * <p>Uses ALL table columns so the SQL text is stable across calls (depends only on the table
+   * schema, not the document shape). This allows the PgJDBC driver to promote it to a server-side
+   * prepared statement after {@code prepareThreshold} executions on the same connection, enabling
+   * Postgres query-plan reuse.
    *
-   * <ul>
-   *   <li>Inserts a new row if no conflict on the primary key
-   *   <li>If the row with that PK already exists, only updates columns present in the document
-   *   <li>Columns NOT in the document retain their existing values (merge behavior)
-   * </ul>
+   * <p>Columns absent from the document are bound as {@code NULL}; the {@code COALESCE} in the SET
+   * clause then preserves their existing values.
    *
    * <p><b>Generated SQL pattern:</b>
    *
    * <pre>{@code
-   * INSERT INTO table (col1, col2, pk_col)
+   * INSERT INTO table (all_col1, all_col2, pk_col)
    * VALUES (?, ?, ?)
-   * ON CONFLICT (pk_col) DO UPDATE SET col1 = EXCLUDED.col1, col2 = EXCLUDED.col2
+   * ON CONFLICT (pk_col) DO UPDATE
+   *   SET all_col1 = COALESCE(EXCLUDED.all_col1, table.all_col1),
+   *       all_col2 = COALESCE(EXCLUDED.all_col2, table.all_col2)
    * RETURNING (xmax = 0) AS is_insert
    * }</pre>
    *
-   * @param docColumns columns present in the document
+   * @param allTableColumns all quoted column names in the table
    * @param pkColumn The quoted primary key column name used for conflict detection
    * @return The complete upsert SQL statement with placeholders for values
    */
-  private String buildUpsertSql(List<String> docColumns, String pkColumn) {
-    return buildMergeUpsertSql(docColumns, pkColumn, true);
+  private String buildUpsertSql(List<String> allTableColumns, String pkColumn) {
+    return buildMergeUpsertSql(allTableColumns, pkColumn, true);
   }
 
   /**
@@ -1626,21 +1598,32 @@ public class FlatPostgresCollection extends PostgresCollection {
         tableIdentifier, columnList, placeholders, pkColumn, setClause);
   }
 
-  private boolean executeUpsert(String sql, TypedDocument parsed) throws SQLException {
-    try (Connection conn = client.getPooledConnection();
-        PreparedStatement ps = conn.prepareStatement(sql)) {
-      int index = 1;
-      for (String column : parsed.getColumns()) {
-        setParameter(
-            conn,
-            ps,
-            index++,
-            parsed.getValue(column),
-            parsed.getType(column),
-            parsed.isArray(column));
-      }
-      try (ResultSet rs = ps.executeQuery()) {
-        return rs.next();
+  private boolean executeUpsert(String sql, List<String> allColumns, TypedDocument parsed)
+      throws SQLException {
+    long ta = System.nanoTime();
+    try (Connection conn = client.getPooledConnection()) {
+      long tb = System.nanoTime();
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int index = 1;
+        Set<String> parsedColumns = new HashSet<>(parsed.getColumns());
+        for (String column : allColumns) {
+          if (parsedColumns.contains(column)) {
+            setParameter(
+                conn,
+                ps,
+                index++,
+                parsed.getValue(column),
+                parsed.getType(column),
+                parsed.isArray(column));
+          } else {
+            ps.setObject(index++, null);
+          }
+        }
+        try (ResultSet rs = ps.executeQuery()) {
+          boolean result = rs.next();
+          long tc = System.nanoTime();
+          return result;
+        }
       }
     }
   }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -354,11 +353,8 @@ public class FlatPostgresCollection extends PostgresCollection {
     PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
 
     try {
-      // Parse all documents and collect the union of all columns. This is because we can have
-      // different docs with different sets of cols, so we do this to create a single upsert SQL
+      // Parse all documents
       Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
-      Set<String> allColumns = new LinkedHashSet<>();
-      allColumns.add(quotedPkColumn);
 
       List<Key> ignoredDocuments = new ArrayList<>();
       for (Map.Entry<Key, Document> entry : documents.entrySet()) {
@@ -374,7 +370,6 @@ public class FlatPostgresCollection extends PostgresCollection {
 
         parsed.add(quotedPkColumn, entry.getKey().toString(), pkType, false);
         parsedDocuments.put(entry.getKey(), parsed);
-        allColumns.addAll(parsed.getColumns());
       }
 
       if (!ignoredDocuments.isEmpty()) {
@@ -389,10 +384,9 @@ public class FlatPostgresCollection extends PostgresCollection {
         return true;
       }
 
-      // Build the bulk upsert SQL with all columns
-      // Use COALESCE to preserve existing values when a document doesn't have a column
-      List<String> columnList = new ArrayList<>(allColumns);
-      String sql = buildMergeUpsertSql(columnList, quotedPkColumn, false);
+      List<String> allTableColumns = getAllQuotedColumns(tableName);
+
+      String sql = buildUpsertSql(allTableColumns, quotedPkColumn, false);
       LOGGER.debug("Bulk upsert SQL: {}", sql);
 
       try (Connection conn = client.getPooledConnection();
@@ -400,10 +394,11 @@ public class FlatPostgresCollection extends PostgresCollection {
 
         for (Map.Entry<Key, TypedDocument> entry : parsedDocuments.entrySet()) {
           TypedDocument parsed = entry.getValue();
+          Set<String> parsedColumns = new HashSet<>(parsed.getColumns());
           int index = 1;
 
-          for (String column : columnList) {
-            if (parsed.getColumns().contains(column)) {
+          for (String column : allTableColumns) {
+            if (parsedColumns.contains(column)) {
               setParameter(
                   conn,
                   ps,
@@ -452,10 +447,8 @@ public class FlatPostgresCollection extends PostgresCollection {
     PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
 
     try {
-      // Parse all documents and collect the union of all columns from documents
+      // Parse all documents
       Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
-      Set<String> docColumns = new LinkedHashSet<>();
-      docColumns.add(quotedPkColumn);
 
       List<Key> ignoredDocuments = new ArrayList<>();
       for (Map.Entry<Key, Document> entry : documents.entrySet()) {
@@ -471,7 +464,6 @@ public class FlatPostgresCollection extends PostgresCollection {
 
         parsed.add(quotedPkColumn, entry.getKey().toString(), pkType, false);
         parsedDocuments.put(entry.getKey(), parsed);
-        docColumns.addAll(parsed.getColumns());
       }
 
       if (!ignoredDocuments.isEmpty()) {
@@ -486,16 +478,10 @@ public class FlatPostgresCollection extends PostgresCollection {
         return true;
       }
 
-      // Get all table columns for the replace semantics (missing cols set to DEFAULT)
-      List<String> allTableColumns =
-          schemaRegistry.getSchema(tableName).values().stream()
-              .map(PostgresColumnMetadata::getName)
-              .map(PostgresUtils::wrapFieldNamesWithDoubleQuotes)
-              .collect(Collectors.toList());
+      List<String> allTableColumns = getAllQuotedColumns(tableName);
 
-      // Build the bulk createOrReplace SQL - uses all table columns with DEFAULT for missing
-      List<String> docColumnList = new ArrayList<>(docColumns);
-      String sql = buildCreateOrReplaceSql(allTableColumns, docColumnList, quotedPkColumn);
+      // Build the bulk createOrReplace SQL - stable shape using all table columns
+      String sql = buildCreateOrReplaceSql(allTableColumns, quotedPkColumn);
       LOGGER.debug("Bulk createOrReplace SQL: {}", sql);
 
       try (Connection conn = client.getPooledConnection();
@@ -503,10 +489,11 @@ public class FlatPostgresCollection extends PostgresCollection {
 
         for (Map.Entry<Key, TypedDocument> entry : parsedDocuments.entrySet()) {
           TypedDocument parsed = entry.getValue();
+          Set<String> parsedColumns = new HashSet<>(parsed.getColumns());
           int index = 1;
 
-          for (String column : docColumnList) {
-            if (parsed.getColumns().contains(column)) {
+          for (String column : allTableColumns) {
+            if (parsedColumns.contains(column)) {
               setParameter(
                   conn,
                   ps,
@@ -595,8 +582,7 @@ public class FlatPostgresCollection extends PostgresCollection {
    * @param includeReturning If true, adds RETURNING clause to detect insert vs update
    * @return The upsert SQL statement
    */
-  private String buildMergeUpsertSql(
-      List<String> columns, String pkColumn, boolean includeReturning) {
+  private String buildUpsertSql(List<String> columns, String pkColumn, boolean includeReturning) {
     String columnList = String.join(", ", columns);
     String placeholders = String.join(", ", columns.stream().map(c -> "?").toArray(String[]::new));
 
@@ -605,10 +591,8 @@ public class FlatPostgresCollection extends PostgresCollection {
             ? PostgresUtils.wrapFieldNamesWithDoubleQuotes(createdTsColumn)
             : null;
 
-    // Build SET clause for non-PK columns.
-    // If useCoalesce is true, use COALESCE(EXCLUDED.col, table.col) to preserve existing values
-    // when the new value is NULL (for bulk upsert merge semantics).
-    // Exclude createdTsColumn from updates to preserve original creation time.
+    // Build SET clause for non-PK, non-createdTs columns using COALESCE(EXCLUDED.col, table.col)
+    // to preserve existing values when the incoming value is NULL (merge semantics).
     String setClause =
         columns.stream()
             .filter(col -> !col.equals(pkColumn))
@@ -1435,17 +1419,12 @@ public class FlatPostgresCollection extends PostgresCollection {
       PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
       parsed.add(quotedPkColumn, key.toString(), pkType, false);
 
-      List<String> docColumns = parsed.getColumns();
-      List<String> allColumns =
-          schemaRegistry.getSchema(tableName).values().stream()
-              .map(PostgresColumnMetadata::getName)
-              .map(PostgresUtils::wrapFieldNamesWithDoubleQuotes)
-              .collect(Collectors.toList());
+      List<String> allColumns = getAllQuotedColumns(tableName);
 
-      String sql = buildCreateOrReplaceSql(allColumns, docColumns, quotedPkColumn);
+      String sql = buildCreateOrReplaceSql(allColumns, quotedPkColumn);
       LOGGER.debug("CreateOrReplace SQL: {}", sql);
 
-      return executeUpsertReturningIsInsert(sql, parsed);
+      return executeUpsertReturningIsInsert(sql, allColumns, parsed);
 
     } catch (PSQLException e) {
       return handlePSQLExceptionForCreateOrReplace(e, key, document, tableName, isRetry);
@@ -1480,12 +1459,12 @@ public class FlatPostgresCollection extends PostgresCollection {
       PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
       parsed.add(quotedPkColumn, key.toString(), pkType, false);
 
-      List<String> docColumns = parsed.getColumns();
+      List<String> allColumns = getAllQuotedColumns(tableName);
 
-      String sql = buildUpsertSql(docColumns, quotedPkColumn);
+      String sql = buildUpsertSql(allColumns, quotedPkColumn);
       LOGGER.debug("Upsert (merge) SQL: {}", sql);
 
-      return executeUpsert(sql, docColumns, parsed);
+      return executeUpsert(sql, allColumns, parsed);
 
     } catch (PSQLException e) {
       return handlePSQLExceptionForUpsert(e, key, document, tableName, isRetry);
@@ -1522,75 +1501,52 @@ public class FlatPostgresCollection extends PostgresCollection {
    * @return The complete upsert SQL statement with placeholders for values
    */
   private String buildUpsertSql(List<String> allTableColumns, String pkColumn) {
-    return buildMergeUpsertSql(allTableColumns, pkColumn, true);
+    return buildUpsertSql(allTableColumns, pkColumn, true);
   }
 
   /**
-   * Builds a PostgreSQL upsert (INSERT ... ON CONFLICT DO UPDATE) SQL statement.
+   * Builds a PostgreSQL upsert (INSERT ... ON CONFLICT DO UPDATE) SQL statement with full-replace
+   * semantics.
    *
-   * <p>This method constructs an atomic upsert query that:
+   * <p>Uses ALL table columns so the SQL text is stable across calls (depends only on the table
+   * schema, not the document shape). This allows the PgJDBC driver to promote it to a server-side
+   * prepared statement after {@code prepareThreshold} executions on the same connection, enabling
+   * Postgres query-plan reuse.
    *
-   * <ul>
-   *   <li>Inserts a new row if no conflict on the primary key
-   *   <li>If the row with that PK already exists, it is replaced in entirety. Cols not present in
-   *       the latest upsert are set to their default values (as defined in the schema)
-   * </ul>
+   * <p>Columns absent from the document are bound as {@code NULL} by the caller; the straight
+   * {@code EXCLUDED.col} in the SET clause then overwrites existing values with NULL, achieving
+   * full-replace semantics.
    *
    * <p><b>Generated SQL pattern:</b>
    *
    * <pre>{@code
-   * INSERT INTO table (col1, col2,, col3, pk_col)
+   * INSERT INTO table (all_col1, all_col2, pk_col)
    * VALUES (?, ?, ?)
-   * ON CONFLICT (pk_col) DO UPDATE SET col1 = EXCLUDED.col1, col2 = EXCLUDED.col2, col3 = DEFAULT
+   * ON CONFLICT (pk_col) DO UPDATE
+   *   SET all_col1 = EXCLUDED.all_col1,
+   *       all_col2 = EXCLUDED.all_col2
    * RETURNING (xmax = 0) AS is_insert
    * }</pre>
    *
-   * <p><b>The EXCLUDED table:</b> In PostgreSQL's ON CONFLICT clause, {@code EXCLUDED} is a special
-   * table that references the row that would have been inserted (the "proposed" row). This allows
-   * us to update existing rows with the new values without re-specifying them.
-   *
-   * <p><b>The RETURNING clause:</b> {@code (xmax = 0) AS is_insert} is a PostgreSQL trick to
-   * determine if the operation was an INSERT or UPDATE:
-   *
-   * <ul>
-   *   <li>{@code xmax} is a system column that stores the transaction ID of the deleting/updating
-   *       transaction
-   *   <li>For a freshly inserted row, {@code xmax = 0} (no prior transaction modified it)
-   *   <li>For an updated row, {@code xmax != 0} (the UPDATE sets it to the current transaction ID)
-   *   <li>Thus, {@code is_insert = true} means INSERT, {@code is_insert = false} means UPDATE
-   * </ul>
-   *
-   * @param allTableColumns all cols present in the table
-   * @param docColumns cols present in the document
+   * @param allTableColumns all quoted column names present in the table
    * @param pkColumn The quoted primary key column name used for conflict detection
    * @return The complete upsert SQL statement with placeholders for values
    */
-  private String buildCreateOrReplaceSql(
-      List<String> allTableColumns, List<String> docColumns, String pkColumn) {
-    String columnList = String.join(", ", docColumns);
+  private String buildCreateOrReplaceSql(List<String> allTableColumns, String pkColumn) {
+    String columnList = String.join(", ", allTableColumns);
     String placeholders =
-        String.join(", ", docColumns.stream().map(c -> "?").toArray(String[]::new));
-    Set<String> docColumnsSet = new HashSet<>(docColumns);
+        String.join(", ", allTableColumns.stream().map(c -> "?").toArray(String[]::new));
 
-    // Build SET clause for non-PK columns: col = EXCLUDED.col
-    // Exclude createdTsColumn from updates to preserve original creation time
     String quotedCreatedTs =
         createdTsColumn != null
             ? PostgresUtils.wrapFieldNamesWithDoubleQuotes(createdTsColumn)
             : null;
-    // Build SET clause for non-PK columns.
+
     String setClause =
         allTableColumns.stream()
             .filter(col -> !col.equals(pkColumn))
             .filter(col -> !col.equals(quotedCreatedTs))
-            .map(
-                col -> {
-                  if (docColumnsSet.contains(col)) {
-                    return col + " = EXCLUDED." + col;
-                  } else {
-                    return col + " = DEFAULT";
-                  }
-                })
+            .map(col -> col + " = EXCLUDED." + col)
             .collect(Collectors.joining(", "));
 
     return String.format(
@@ -1629,19 +1585,24 @@ public class FlatPostgresCollection extends PostgresCollection {
   }
 
   /** Returns true if INSERT, false if UPDATE. */
-  private boolean executeUpsertReturningIsInsert(String sql, TypedDocument parsed)
-      throws SQLException {
+  private boolean executeUpsertReturningIsInsert(
+      String sql, List<String> allColumns, TypedDocument parsed) throws SQLException {
     try (Connection conn = client.getPooledConnection();
         PreparedStatement ps = conn.prepareStatement(sql)) {
       int index = 1;
-      for (String column : parsed.getColumns()) {
-        setParameter(
-            conn,
-            ps,
-            index++,
-            parsed.getValue(column),
-            parsed.getType(column),
-            parsed.isArray(column));
+      Set<String> parsedColumns = new HashSet<>(parsed.getColumns());
+      for (String column : allColumns) {
+        if (parsedColumns.contains(column)) {
+          setParameter(
+              conn,
+              ps,
+              index++,
+              parsed.getValue(column),
+              parsed.getType(column),
+              parsed.isArray(column));
+        } else {
+          ps.setObject(index++, null);
+        }
       }
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
@@ -1715,6 +1676,13 @@ public class FlatPostgresCollection extends PostgresCollection {
         .getColumnOrRefresh(tableName, pkColumn)
         .map(PostgresColumnMetadata::getPostgresType)
         .orElse(PostgresDataType.TEXT);
+  }
+
+  private List<String> getAllQuotedColumns(String tableName) {
+    return schemaRegistry.getSchema(tableName).values().stream()
+        .map(PostgresColumnMetadata::getName)
+        .map(PostgresUtils::wrapFieldNamesWithDoubleQuotes)
+        .collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
## Description
Ref: https://github.com/hypertrace/document-store/issues/290

## Stable SQL shape for flat collection upsert/createOrReplace

Previously, the SQL generated for `upsert` and `createOrReplace` operations varied based on the document's fields. This prevented PgJDBC from promoting queries to server-side prepared statements, since each unique SQL string is treated as a new statement.

Now, all four write methods (`upsert`, `bulkUpsert`, `createOrReplace`, `bulkCreateOrReplace`) always use all table columns in the generated SQL, producing a stable shape that depends only on the table schema.

### Upsert (merge semantics)

**Before:**
```sql
INSERT INTO "myTable" ("id", "price")
VALUES (?, ?)
ON CONFLICT ("id") DO UPDATE SET "price" = COALESCE(EXCLUDED."price", "myTable"."price")
```

**After:**
```sql
INSERT INTO "myTable" ("id", "price", "item", "quantity")
VALUES (?, ?, ?, ?)
ON CONFLICT ("id") DO UPDATE SET
  "price" = COALESCE(EXCLUDED."price", "myTable"."price"),
  "item" = COALESCE(EXCLUDED."item", "myTable"."item"),
  "quantity" = COALESCE(EXCLUDED."quantity", "myTable"."quantity")
```

Missing columns are bound as `NULL`; `COALESCE` preserves existing values.

### CreateOrReplace (full-replace semantics)

**Before:**
```sql
INSERT INTO "myTable" ("id", "price")
VALUES (?, ?)
ON CONFLICT ("id") DO UPDATE SET
  "price" = EXCLUDED."price",
  "item" = DEFAULT,
  "quantity" = DEFAULT
```

**After:**
```sql
INSERT INTO "myTable" ("id", "price", "item", "quantity")
VALUES (?, ?, ?, ?)
ON CONFLICT ("id") DO UPDATE SET
  "price" = EXCLUDED."price",
  "item" = EXCLUDED."item",
  "quantity" = EXCLUDED."quantity"
```

Missing columns are bound as `NULL`; `EXCLUDED.col` overwrites with `NULL` (full-replace).

Essentially, both `upsert` and `createOrReplace` bind `NULL` for missing columns. What changes is how the `SET` clause handles that `NULL`:

`Upsert`: `SET col = COALESCE(EXCLUDED.col, table.col)` → `NULL` is ignored, existing value kept
`CreateOrReplace`: `SET col = EXCLUDED.col` → `NULL` overwrites the existing value

