### PR TITLE
Remove transaction isolation level config in PG

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
@@ -1,7 +1,5 @@
 package org.hypertrace.core.documentstore.postgres;
 
-import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -101,7 +99,10 @@ class PostgresConnectionPool {
     poolableConnectionFactory.setValidationQueryTimeout((int) VALIDATION_QUERY_TIMEOUT.toSeconds());
     poolableConnectionFactory.setDefaultReadOnly(false);
     poolableConnectionFactory.setDefaultAutoCommit(true);
-    poolableConnectionFactory.setDefaultTransactionIsolation(TRANSACTION_READ_COMMITTED);
+    // Note: We intentionally do NOT call setDefaultTransactionIsolation() here.
+    // PostgreSQL defaults to READ_COMMITTED, which is what we want. Setting it explicitly
+    // causes DBCP2 to execute "SHOW TRANSACTION ISOLATION LEVEL" on every connection borrow
+    // (via PgConnection.getTransactionIsolation()), adding unnecessary overhead.
     poolableConnectionFactory.setPoolStatements(false);
   }
 


### PR DESCRIPTION
## Description
This PR removes `poolableConnectionFactory.setDefaultTransactionIsolation(TRANSACTION_READ_COMMITTED);`.  `TRANSACTION_READ_COMMITTED` is already the default - However, setting this setting it explicitly causes DBCP2 to execute `SHOW TRANSACTION ISOLATION LEVEL` on every connection borrow which is highly sub-optimal. We observed that with this configuration, `getPooledConnection` is almost ~ 50% of the wall-clock time in `executeUpsert` call. However, with this removed, it's ~ 0.46%.

With Config:

<img width="1695" height="117" alt="Screenshot 2026-05-05 at 2 02 11 PM" src="https://github.com/user-attachments/assets/adc56aae-81d5-4fd8-a147-9289267d95e5" />


Without Config (the frame for `getPooledConnection` is not visible since it's so small):

<img width="1728" height="69" alt="Screenshot 2026-05-05 at 2 02 56 PM" src="https://github.com/user-attachments/assets/79f4cb97-2c66-4c0d-98b7-94f0e96021ce" />



