### PR TITLE
Bind arrays correctly in PG updates

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -1122,9 +1122,7 @@ public class FlatPostgresCollection extends PostgresCollection {
       for (Object param : params) {
         ps.setObject(idx++, param);
       }
-      for (Object param : filterParams.getObjectParams().values()) {
-        ps.setObject(idx++, param);
-      }
+      filterParams.bindTo(connection, ps, idx);
       int rowsUpdated = ps.executeUpdate();
       LOGGER.debug("Rows updated: {}", rowsUpdated);
     } catch (SQLException e) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/Params.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/Params.java
@@ -1,5 +1,9 @@
 package org.hypertrace.core.documentstore.postgres;
 
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -24,6 +28,21 @@ public class Params {
 
   public Map<Integer, Object> getObjectParams() {
     return objectParams;
+  }
+
+  public int bindTo(Connection connection, PreparedStatement ps, int startIndex)
+      throws SQLException {
+    int idx = startIndex;
+    for (Object value : objectParams.values()) {
+      if (value instanceof ArrayParam) {
+        ArrayParam arrayParam = (ArrayParam) value;
+        Array sqlArray = connection.createArrayOf(arrayParam.getSqlType(), arrayParam.getValues());
+        ps.setArray(idx++, sqlArray);
+      } else {
+        ps.setObject(idx++, value);
+      }
+    }
+    return idx;
   }
 
   public static Builder newBuilder() {


### PR DESCRIPTION
## Fix: `ArrayParam` support in UPDATE execution path

### Problem

PR #258 added `= ANY(?)` optimization for SELECT queries, replacing `IN ($1, $2, ..., $N)` with a single array parameter. However, the UPDATE path in `FlatPostgresCollection.executeUpdate()` bound WHERE clause params with a raw `setObject()` loop, which doesn't know how to handle the `Params.ArrayParam` wrapper:

```
PSQLException: Can't infer the SQL type to use for an instance of
org.hypertrace.core.documentstore.postgres.Params$ArrayParam.
SQLState: 07006
```

**Affected query pattern:**
```sql
UPDATE "entities_api_shadow"
  SET "attributes.labels" = ?, "lastUpdateTime" = ?
  WHERE "key" = ANY(?)
                  ^^^^ ArrayParam not unwrapped
```

The SELECT path already handled this correctly via `PostgresUtils.enrichPreparedStatementWithParams()`, but the UPDATE path was a separate code path that bypassed it.

### Fix

**`Params.java`** — Added `bindTo(Connection, PreparedStatement, int startIndex)` method that encapsulates `ArrayParam` → `createArrayOf` → `setArray` dispatch. Returns the next unused index for chaining.

**`FlatPostgresCollection.java`** — Replaced the raw `setObject()` loop for filter params with a single call:

```java
// Before
for (Object param : filterParams.getObjectParams().values()) {
    ps.setObject(idx++, param);  // breaks on ArrayParam
}

// After
filterParams.bindTo(connection, ps, idx);
```

This is already being done here: https://github.com/hypertrace/document-store/blob/3bcae6c10d4c38fad4b629a22eba5173be1ce08c/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/utils/PostgresUtils.java#L595
