### PR TITLE
[Draft] Use $sum instead of $push to optimise Mongo group queries

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/parser/MongoAggregateExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/parser/MongoAggregateExpressionParser.java
@@ -12,9 +12,11 @@ import static org.hypertrace.core.documentstore.expression.operators.Aggregation
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.getUnsupportedOperationException;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import lombok.NoArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
+import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.operators.AggregationOperator;
 import org.hypertrace.core.documentstore.parser.SelectTypeExpressionVisitor;
 
@@ -47,12 +49,29 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
   Map<String, Object> parse(final AggregateExpression expression) {
     AggregationOperator operator = expression.getAggregator();
 
-    // MongoDB has no native COUNT accumulator. Implement COUNT as $sum: 1, which increments a
-    // counter per document, instead of collecting every value into an array via $push (followed
-    // by $size). The $push approach materializes one array element per matching document, which is
-    // memory-intensive, can spill to disk, and fails with a BSON 16MB error for very large groups.
+    SelectTypeExpressionVisitor parser =
+        new MongoIdentifierPrefixingParser(
+            new MongoIdentifierExpressionParser(
+                new MongoAggregateExpressionParser(
+                    new MongoFunctionExpressionParser(new MongoConstantExpressionParser()))));
+
+    // MongoDB has no native COUNT accumulator. Implement COUNT with $sum instead of collecting
+    // every value into an array via $push (followed by $size). The $push approach materializes one
+    // array element per matching document, which is memory-intensive and can spill to disk.
+    //
+    // The previous $push semantics are preserved:
+    //  - COUNT(<constant>) counts every document in the group (i.e. COUNT(*)).
+    //  - COUNT(<field/expr>) counts only documents where the operand is present (not missing),
+    //    matching $push, which skips missing values. ($type returns "missing" for absent fields.)
     if (operator == COUNT) {
-      return Map.of("$sum", 1);
+      if (expression.getExpression() instanceof ConstantExpression) {
+        return Map.of("$sum", 1);
+      }
+
+      Object operand = expression.getExpression().accept(parser);
+      return Map.of(
+          "$sum",
+          Map.of("$cond", List.of(Map.of("$ne", List.of(Map.of("$type", operand), "missing")), 1, 0)));
     }
 
     String key = KEY_MAP.get(operator);
@@ -60,12 +79,6 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
     if (key == null) {
       throw getUnsupportedOperationException(operator);
     }
-
-    SelectTypeExpressionVisitor parser =
-        new MongoIdentifierPrefixingParser(
-            new MongoIdentifierExpressionParser(
-                new MongoAggregateExpressionParser(
-                    new MongoFunctionExpressionParser(new MongoConstantExpressionParser()))));
 
     Object value = expression.getExpression().accept(parser);
     return Map.of(key, value);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/parser/MongoAggregateExpressionParser.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/parser/MongoAggregateExpressionParser.java
@@ -30,7 +30,6 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
               put(SUM, "$sum");
               put(MIN, "$min");
               put(MAX, "$max");
-              put(COUNT, "$push");
               put(LAST, "$last");
             }
           });
@@ -47,6 +46,15 @@ final class MongoAggregateExpressionParser extends MongoSelectTypeExpressionPars
 
   Map<String, Object> parse(final AggregateExpression expression) {
     AggregationOperator operator = expression.getAggregator();
+
+    // MongoDB has no native COUNT accumulator. Implement COUNT as $sum: 1, which increments a
+    // counter per document, instead of collecting every value into an array via $push (followed
+    // by $size). The $push approach materializes one array element per matching document, which is
+    // memory-intensive, can spill to disk, and fails with a BSON 16MB error for very large groups.
+    if (operator == COUNT) {
+      return Map.of("$sum", 1);
+    }
+
     String key = KEY_MAP.get(operator);
 
     if (key == null) {

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/transformer/MongoSelectionsAddingTransformation.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/mongo/query/transformer/MongoSelectionsAddingTransformation.java
@@ -1,6 +1,5 @@
 package org.hypertrace.core.documentstore.mongo.query.transformer;
 
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_COUNT;
 import static org.hypertrace.core.documentstore.expression.operators.FunctionOperator.LENGTH;
 import static org.hypertrace.core.documentstore.mongo.MongoUtils.encodeKey;
@@ -86,10 +85,11 @@ final class MongoSelectionsAddingTransformation implements SelectTypeExpressionV
     final String encodedAlias = encodeKey(alias);
     final SelectTypeExpression pairingExpression;
 
-    if (expression.getAggregator() == DISTINCT_COUNT || expression.getAggregator() == COUNT) {
-      // Since MongoDB doesn't support $distinctCount and $count(optional_field) in aggregations,
-      // we convert them to $addToSet and $push functions respectively.
-      // So, we need to project $size(set) or $size(list) instead of just the alias in these cases.
+    if (expression.getAggregator() == DISTINCT_COUNT) {
+      // Since MongoDB doesn't support $distinctCount in aggregations, we convert it to $addToSet.
+      // So, we need to project $size(set) instead of just the alias in this case.
+      // (COUNT is implemented as $sum and already yields a scalar, so it falls into the else
+      // branch.)
       pairingExpression =
           FunctionExpression.builder()
               .operator(LENGTH)

--- a/document-store/src/test/resources/mongo/pipeline/field_count.json
+++ b/document-store/src/test/resources/mongo/pipeline/field_count.json
@@ -3,15 +3,13 @@
     "$group": {
       "_id": null,
       "total": {
-        "$push": "$path"
+        "$sum": 1
       }
     }
   },
   {
     "$project": {
-      "total": {
-        "$size": "$total"
-      }
+      "total": "$total"
     }
   }
 ]

--- a/document-store/src/test/resources/mongo/pipeline/field_count.json
+++ b/document-store/src/test/resources/mongo/pipeline/field_count.json
@@ -3,7 +3,20 @@
     "$group": {
       "_id": null,
       "total": {
-        "$sum": 1
+        "$sum": {
+          "$cond": [
+            {
+              "$ne": [
+                {
+                  "$type": "$path"
+                },
+                "missing"
+              ]
+            },
+            1,
+            0
+          ]
+        }
       }
     }
   },

--- a/document-store/src/test/resources/mongo/pipeline/optimize_sorts_simple_sort_with_aggregation_selection.json
+++ b/document-store/src/test/resources/mongo/pipeline/optimize_sorts_simple_sort_with_aggregation_selection.json
@@ -2,16 +2,14 @@
   {
     "$group": {
       "total": {
-        "$push": 1
+        "$sum": 1
       },
       "_id": null
     }
   },
   {
     "$project": {
-      "total": {
-        "$size": "$total"
-      }
+      "total": "$total"
     }
   },
   {

--- a/document-store/src/test/resources/mongo/pipeline/simple.json
+++ b/document-store/src/test/resources/mongo/pipeline/simple.json
@@ -3,15 +3,13 @@
     "$group": {
       "_id": null,
       "total": {
-        "$push": 1
+        "$sum": 1
       }
     }
   },
   {
     "$project": {
-      "total": {
-        "$size": "$total"
-      }
+      "total": "$total"
     }
   }
 ]

--- a/document-store/src/test/resources/mongo/pipeline/with_projections.json
+++ b/document-store/src/test/resources/mongo/pipeline/with_projections.json
@@ -3,16 +3,14 @@
     "$group": {
       "_id": null,
       "total": {
-        "$push": 1
+        "$sum": 1
       }
     }
   },
   {
     "$project": {
       "name": 1,
-      "total": {
-        "$size": "$total"
-      }
+      "total": "$total"
     }
   }
 ]


### PR DESCRIPTION
# Optimize Mongo `COUNT` aggregation: `$sum` instead of `$push` + `$size`

## Summary

The document-store library compiled `COUNT(<expr>)` for MongoDB into a `$push` accumulator
that collected **every** value into an in-memory array, then took its length with `$size` in a
follow-up `$project`:

```js
$group:   { "<alias>": { $push: "$entityId" }, _id: { ... } }
$project: { "<alias>": { $size: "$<alias>" }, ... }
```

This materializes one array element per matching document just to count them. This change makes
`COUNT` emit a `$sum` accumulator instead — O(1) memory per group, no array, no spill — while
**preserving the existing semantics**:

```js
// COUNT(<constant>)  ->  COUNT(*): count every document in the group
$group:   { _id: { ... }, "<alias>": { $sum: 1 } }
$project: { "<alias>": "$<alias>", ... }

// COUNT(<field/expr>) ->  count only documents where the operand is present (not missing),
//                         matching the old $push behavior (which skipped missing values)
$group:   { _id: { ... }, "<alias>": { $sum: { $cond: [ { $ne: [ { $type: "$<field>" }, "missing" ] }, 1, 0 ] } } }
$project: { "<alias>": "$<alias>", ... }
```

## Performance Evidence

Both plans below are the **same query, same filter, same index** (`tenantId_isLearnt_index`),
on `default_db.application_asset_entities` for a tenant with ~459K matching documents
(`explain("executionStats")`, MongoDB 8.0.20). The only difference is the `COUNT` compilation.
The "after" plan was captured with the `$sum: 1` (`COUNT(*)`) form.

| Metric | Before (`$push` + `$size`) | After (`$sum`) |
|---|---|---|
| **executionTimeMillis** | **13,753 ms** | **7,134 ms** |
| `$group` accumulator | `addToArrayCapped(entityId, 104857600)` | `count()` |
| `$group` stage time (est.) | ~13,555 ms | ~7,084 ms |
| nReturned (groups) | 4 | 4 |

**Result: ~48% faster** (13.75s -> 7.13s) on this dataset. The dominant saving is eliminating the
per-group array build (`$group` stage time drops from ~13.5s to ~80ms over its input); the
`$cond` presence-guard form for `COUNT(<field>)` removes the same array work, so it gets the same
class of improvement.

## Out of scope (follow-up)

Note on full index coverage: the most efficient form (`$sum: 1`, reading no document fields) is
produced for `COUNT(<constant>)`. For `COUNT(<field>)` the presence guard reads the field, so it
cannot be fully index-covered. The production asset-count query currently uses `COUNT(fieldName)`;
if the intent is "count documents" (entityId is always present), the caller should issue
`COUNT(*)` / `COUNT(1)` to enable a fully index-covered, sub-second plan together with the
covering index.
