### PR TITLE
Make dbcp2 testOnBorrow configurable

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/ConnectionPoolConfig.java
@@ -28,4 +28,7 @@ public class ConnectionPoolConfig {
 
   // Time duration to wait for surrendering an idle connection back to the pool
   @NonNull @Builder.Default Duration connectionSurrenderTimeout = Duration.ofMinutes(5);
+
+  // Whether to validate connections when borrowing from the pool
+  @NonNull @Builder.Default Boolean testOnBorrow = true;
 }

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/PostgresConnectionPool.java
@@ -81,14 +81,16 @@ class PostgresConnectionPool {
     connectionPool.setMinIdle(getIdleCount(poolConfig.minIdlePercent(), maxConnections));
     connectionPool.setBlockWhenExhausted(true);
     connectionPool.setMaxWaitMillis(poolConfig.connectionAccessTimeout().toMillis());
+    connectionPool.setTestOnBorrow(poolConfig.testOnBorrow());
     connectionPool.setAbandonedConfig(abandonedConfig);
     log.debug(
-        "Postgres connection pool properties - maxTotal: {}, maxIdle: {}, minIdle: {}, maxWaitMillis: {}, connectionSurrenderTimeout: {}",
+        "Postgres connection pool properties - maxTotal: {}, maxIdle: {}, minIdle: {}, maxWaitMillis: {}, connectionSurrenderTimeout: {}, testOnBorrow: {}",
         connectionPool.getMaxTotal(),
         connectionPool.getMaxIdle(),
         connectionPool.getMinIdle(),
         connectionPool.getMaxWaitMillis(),
-        poolConfig.connectionSurrenderTimeout());
+        poolConfig.connectionSurrenderTimeout(),
+        poolConfig.testOnBorrow());
   }
 
   private void setFactoryProperties(


### PR DESCRIPTION
## Description
Adds configuration support for `testOnBorrow` in the Postgres connection pool with a default value of `true`. This ensures connections are validated before being borrowed from the pool, preventing stale or broken connections from being handed to the application. 

Before this, default is false

```
  /**
     * The default value for the {@code testOnBorrow} configuration attribute.
     * @see GenericObjectPool#getTestOnBorrow()
     * @see GenericKeyedObjectPool#getTestOnBorrow()
     */
    public static final boolean DEFAULT_TEST_ON_BORROW = false;
```