### PR TITLE
Suppress Jackson Databind 2.18.8 for CVE-2026-54515

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ org-mockito = "5.8.0"
 org-testcontainers = "1.17.6"
 
 [libraries]
-com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.9" }
+com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.8" }
 com-github-java-json-tools-json-patch = { module = "com.github.java-json-tools:json-patch", version = "1.13" }
 com-google-guava = { module = "com.google.guava:guava", version = "32.0.1-jre" }
 com-typesafe-config = { module = "com.typesafe:config", version = "1.4.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ org-mockito = "5.8.0"
 org-testcontainers = "1.17.6"
 
 [libraries]
-com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.8" }
+com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.9" }
 com-github-java-json-tools-json-patch = { module = "com.github.java-json-tools:json-patch", version = "1.13" }
 com-google-guava = { module = "com.google.guava:guava", version = "32.0.1-jre" }
 com-typesafe-config = { module = "com.typesafe:config", version = "1.4.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ org-mockito = "5.8.0"
 org-testcontainers = "1.17.6"
 
 [libraries]
-com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.21.5" }
+com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.9" }
 com-github-java-json-tools-json-patch = { module = "com.github.java-json-tools:json-patch", version = "1.13" }
 com-google-guava = { module = "com.google.guava:guava", version = "32.0.1-jre" }
 com-typesafe-config = { module = "com.typesafe:config", version = "1.4.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ org-mockito = "5.8.0"
 org-testcontainers = "1.17.6"
 
 [libraries]
-com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.18.9" }
+com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.21.5" }
 com-github-java-json-tools-json-patch = { module = "com.github.java-json-tools:json-patch", version = "1.13" }
 com-google-guava = { module = "com.google.guava:guava", version = "32.0.1-jre" }
 com-typesafe-config = { module = "com.typesafe:config", version = "1.4.2" }

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -17,4 +17,15 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-21469</vulnerabilityName>
   </suppress>
+  <suppress until="2026-08-31Z">
+    <notes><![CDATA[
+   file name: jackson-databind-2.18.8.jar
+   GHSA-5jmj-h7xm-6q6v. Fixed upstream in 2.18.9/2.21.5/2.22.1/3.1.4, but none of those
+   artifacts are published to Maven Central yet, so we cannot bump.
+   Time-boxed suppression until the 2.18.9 patch release is available; remove this entry and
+   bump jackson-bom to 2.18.9 once it resolves.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>REPLACE_WITH_CVE_FROM_ADVISORY</cve>
+  </suppress>
 </suppressions> 

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -26,6 +26,6 @@
    bump jackson-bom to 2.18.9 once it resolves.
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <cve>REPLACE_WITH_CVE_FROM_ADVISORY</cve>
+    <vulnerabilityName>CVE-2026-54515</vulnerabilityName>
   </suppress>
 </suppressions> 


### PR DESCRIPTION
Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-54515 and https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v

Edit: Looks like none of the versions is released to maven central yet, thus the build is failing: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/

Added a suppression to handle this. 

