### PR TITLE
Read testOnBorrow correctly from config

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractor.java
@@ -34,6 +34,7 @@ public class TypesafeConfigDatastoreConfigExtractor {
   private static final String DEFAULT_CONNECTION_IDLE_TIME_KEY = "connectionIdleTime";
   private static final String DEFAULT_MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
   private static final String DEFAULT_MIN_IDLE_PERCENT_KEY = "minIdlePercent";
+  private static final String DEFAULT_TEST_ON_BORROW_KEY = "testOnBorrow";
   private static final String DEFAULT_AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DEFAULT_DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String DEFAULT_QUERY_TIMEOUT_KEY = "queryTimeout";
@@ -88,6 +89,7 @@ public class TypesafeConfigDatastoreConfigExtractor {
         .poolConnectionSurrenderTimeoutKey(DEFAULT_CONNECTION_IDLE_TIME_KEY)
         .poolMaxIdlePercentKey(DEFAULT_MAX_IDLE_PERCENT_KEY)
         .poolMinIdlePercentKey(DEFAULT_MIN_IDLE_PERCENT_KEY)
+        .poolTestOnBorrowKey(DEFAULT_TEST_ON_BORROW_KEY)
         .aggregationPipelineMode(DEFAULT_AGGREGATION_PIPELINE_MODE_KEY)
         .dataFreshnessKey(DEFAULT_DATA_FRESHNESS_KEY)
         .queryTimeoutKey(DEFAULT_QUERY_TIMEOUT_KEY)
@@ -242,6 +244,13 @@ public class TypesafeConfigDatastoreConfigExtractor {
   public TypesafeConfigDatastoreConfigExtractor poolMinIdlePercentKey(@NonNull final String key) {
     if (config.hasPath(key)) {
       connectionPoolConfigBuilder.minIdlePercent(config.getInt(key));
+    }
+    return this;
+  }
+
+  public TypesafeConfigDatastoreConfigExtractor poolTestOnBorrowKey(@NonNull final String key) {
+    if (config.hasPath(key)) {
+      connectionPoolConfigBuilder.testOnBorrow(config.getBoolean(key));
     }
     return this;
   }

--- a/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
+++ b/document-store/src/test/java/org/hypertrace/core/documentstore/model/config/TypesafeConfigDatastoreConfigExtractorTest.java
@@ -36,6 +36,7 @@ class TypesafeConfigDatastoreConfigExtractorTest {
   private static final String CONNECTION_SURRENDER_TIMEOUT_KEY = "connectionSurrenderTimeout";
   private static final String MAX_IDLE_PERCENT_KEY = "maxIdlePercent";
   private static final String MIN_IDLE_PERCENT_KEY = "minIdlePercent";
+  private static final String TEST_ON_BORROW_KEY = "testOnBorrow";
   private static final String AGGREGATION_PIPELINE_MODE_KEY = "aggregationPipelineMode";
   private static final String DATA_FRESHNESS_KEY = "dataFreshness";
   private static final String QUERY_TIMEOUT_KEY = "queryTimeout";
@@ -470,6 +471,51 @@ class TypesafeConfigDatastoreConfigExtractorTest {
     final ConnectionPoolConfig poolConfig = config.connectionPoolConfig();
     assertEquals(maxIdlePercent, poolConfig.maxIdlePercent());
     assertEquals(minIdlePercent, poolConfig.minIdlePercent());
+  }
+
+  @Test
+  void testDefaultTestOnBorrowValue() {
+    final PostgresConnectionConfig config =
+        (PostgresConnectionConfig)
+            TypesafeConfigDatastoreConfigExtractor.from(buildConfigMap(), DatabaseType.POSTGRES)
+                .hostKey(HOST_KEY)
+                .portKey(PORT_KEY)
+                .databaseKey(DATABASE_KEY)
+                .usernameKey(USER_KEY)
+                .passwordKey(PASSWORD_KEY)
+                .extract()
+                .connectionConfig();
+
+    assertEquals(true, config.connectionPoolConfig().testOnBorrow());
+  }
+
+  @Test
+  void testCustomTestOnBorrowValue() {
+    final PostgresConnectionConfig config =
+        (PostgresConnectionConfig)
+            TypesafeConfigDatastoreConfigExtractor.from(
+                    buildConfigMapWithTestOnBorrow(), DatabaseType.POSTGRES)
+                .hostKey(HOST_KEY)
+                .portKey(PORT_KEY)
+                .databaseKey(DATABASE_KEY)
+                .usernameKey(USER_KEY)
+                .passwordKey(PASSWORD_KEY)
+                .poolTestOnBorrowKey(TEST_ON_BORROW_KEY)
+                .extract()
+                .connectionConfig();
+
+    assertEquals(false, config.connectionPoolConfig().testOnBorrow());
+  }
+
+  private Config buildConfigMapWithTestOnBorrow() {
+    return ConfigFactory.parseMap(
+        Map.ofEntries(
+            entry(HOST_KEY, host),
+            entry(PORT_KEY, port),
+            entry(DATABASE_KEY, database),
+            entry(USER_KEY, user),
+            entry(PASSWORD_KEY, password),
+            entry(TEST_ON_BORROW_KEY, false)));
   }
 
   private Config buildConfigMapWithIdlePercent() {


### PR DESCRIPTION
## Description
There was a bug in the earlier PR that it was not reading this key from the config. This PR fixes it. Test this in a live env:

```
2026-07-02 07:44:50.032 [main] DEBUG o.h.c.d.p.PostgresConnectionPool - Postgres connection pool properties - maxTotal: 10, maxIdle: 2, minIdle: 1, maxWaitMillis: 10000, connectionSurrenderTimeout: PT5M, testOnBorrow: false
```