### PR TITLE
[FlatPostgresCollection] Sort keys before preparedStatement.addBatch() to prevent deadlocks

### DIFF
--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -1032,6 +1032,7 @@ public class FlatPostgresCollection extends PostgresCollection {
     for (int i = 0; i < order.length; i++) {
       order[i] = i;
     }
+    // Sort keys to ensure consistent order to avoid deadlocks
     Arrays.sort(order, Comparator.comparing(i -> keys.get(i).toString()));
 
     List<String> setFragments = new ArrayList<>(keyGroup.getSetFragments());

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -364,7 +365,7 @@ public class FlatPostgresCollection extends PostgresCollection {
       Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
 
       List<Key> ignoredDocuments = new ArrayList<>();
-      for (Map.Entry<Key, Document> entry : documents.entrySet()) {
+      for (Map.Entry<Key, Document> entry : sortedByKey(documents)) {
         List<String> skippedFields = new ArrayList<>();
         TypedDocument parsed = parseDocument(entry.getValue(), tableName, skippedFields);
 
@@ -458,7 +459,7 @@ public class FlatPostgresCollection extends PostgresCollection {
       Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
 
       List<Key> ignoredDocuments = new ArrayList<>();
-      for (Map.Entry<Key, Document> entry : documents.entrySet()) {
+      for (Map.Entry<Key, Document> entry : sortedByKey(documents)) {
         List<String> skippedFields = new ArrayList<>();
         TypedDocument parsed = parseDocument(entry.getValue(), tableName, skippedFields);
 
@@ -663,6 +664,12 @@ public class FlatPostgresCollection extends PostgresCollection {
         LOGGER.warn("Error closing connection after exception", closeEx);
       }
     }
+  }
+
+  private static List<Map.Entry<Key, Document>> sortedByKey(Map<Key, Document> documents) {
+    List<Map.Entry<Key, Document>> sorted = new ArrayList<>(documents.entrySet());
+    sorted.sort(Comparator.comparing(entry -> entry.getKey().toString()));
+    return sorted;
   }
 
   private PreparedStatement getPreparedStatementForQuery(
@@ -1022,6 +1029,12 @@ public class FlatPostgresCollection extends PostgresCollection {
     List<Key> keys = keyGroup.getKeys();
     List<List<Object>> allKeyParams = keyGroup.getKeyParams();
 
+    Integer[] order = new Integer[keys.size()];
+    for (int i = 0; i < order.length; i++) {
+      order[i] = i;
+    }
+    Arrays.sort(order, Comparator.comparing(i -> keys.get(i).toString()));
+
     List<String> setFragments = new ArrayList<>(keyGroup.getSetFragments());
     List<Object> timestampParam = new ArrayList<>();
     appendLastUpdatedTimestamp(setFragments, timestampParam, tableName, epochMillis);
@@ -1034,7 +1047,7 @@ public class FlatPostgresCollection extends PostgresCollection {
     LOGGER.debug("Executing batch update SQL: {} for {} keys", sql, keys.size());
 
     try (PreparedStatement ps = connection.prepareStatement(sql)) {
-      for (int i = 0; i < keys.size(); i++) {
+      for (int i : order) {
         int idx = 1;
         for (Object param : allKeyParams.get(i)) {
           ps.setObject(idx++, param);

--- a/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
+++ b/document-store/src/main/java/org/hypertrace/core/documentstore/postgres/FlatPostgresCollection.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.hypertrace.core.documentstore.BulkArrayValueUpdateRequest;
 import org.hypertrace.core.documentstore.BulkDeleteResult;
@@ -361,11 +362,13 @@ public class FlatPostgresCollection extends PostgresCollection {
     PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
 
     try {
-      // Parse all documents
-      Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
+      // TreeMap keyed by Key.toString() so the downstream JDBC batch iterates rows in a canonical
+      // order. Postgres acquires row locks in batch-entry order, so overlapping concurrent batches
+      // must share an ordering to avoid deadlocks.
+      Map<Key, TypedDocument> parsedDocuments = new TreeMap<>(Comparator.comparing(Key::toString));
 
       List<Key> ignoredDocuments = new ArrayList<>();
-      for (Map.Entry<Key, Document> entry : sortedByKey(documents)) {
+      for (Map.Entry<Key, Document> entry : documents.entrySet()) {
         List<String> skippedFields = new ArrayList<>();
         TypedDocument parsed = parseDocument(entry.getValue(), tableName, skippedFields);
 
@@ -455,11 +458,13 @@ public class FlatPostgresCollection extends PostgresCollection {
     PostgresDataType pkType = getPrimaryKeyType(tableName, pkColumn);
 
     try {
-      // Parse all documents
-      Map<Key, TypedDocument> parsedDocuments = new LinkedHashMap<>();
+      // TreeMap keyed by Key.toString() so the downstream JDBC batch iterates rows in a canonical
+      // order. Postgres acquires row locks in batch-entry order, so overlapping concurrent batches
+      // must share an ordering to avoid deadlocks.
+      Map<Key, TypedDocument> parsedDocuments = new TreeMap<>(Comparator.comparing(Key::toString));
 
       List<Key> ignoredDocuments = new ArrayList<>();
-      for (Map.Entry<Key, Document> entry : sortedByKey(documents)) {
+      for (Map.Entry<Key, Document> entry : documents.entrySet()) {
         List<String> skippedFields = new ArrayList<>();
         TypedDocument parsed = parseDocument(entry.getValue(), tableName, skippedFields);
 
@@ -664,12 +669,6 @@ public class FlatPostgresCollection extends PostgresCollection {
         LOGGER.warn("Error closing connection after exception", closeEx);
       }
     }
-  }
-
-  private static List<Map.Entry<Key, Document>> sortedByKey(Map<Key, Document> documents) {
-    List<Map.Entry<Key, Document>> sorted = new ArrayList<>(documents.entrySet());
-    sorted.sort(Comparator.comparing(entry -> entry.getKey().toString()));
-    return sorted;
   }
 
   private PreparedStatement getPreparedStatementForQuery(


### PR DESCRIPTION
# Sort keys to prevent deadlocks in batched writes on FlatPostgresCollection

## Summary

 Enforces a canonical, string-sorted key order across all JDBC-batched, key-keyed write operations in FlatPostgresCollection. Postgres acquires per-row locks in batch-entry order for `INSERT ... ON CONFLICT DO UPDATE` and `UPDATE ... WHERE key = ?`, so two concurrent batches that touch overlapping key sets in opposite orders can form a wait-for cycle and one side gets aborted with ERROR: deadlock detected (SQLState `40P01`).

  Sorting inside the store — the last hop before `addBatch(...)` — makes the invariant local to the collection and independent of caller iteration order, so no downstream service has to remember to sort.

  Symptom this fixes

  Callers were seeing production log lines like:

```sql
Failed to execute batch update. SQL: UPDATE "myTable" SET "attributes.col1" = ?, "col2" = ? WHERE "pkCol" = ?
Error: Batch entry 8 UPDATE "myTable" ... was aborted:
ERROR: deadlock detected.
```

The offending SQL is produced only by the Map-based `bulkUpdate` on this class, and the deadlock reproduces trivially with two concurrent callers that iterate overlapping keys in opposite orders. The same class of bug also exists on `bulkUpsert` / `bulkCreateOrReplace`, which batch `INSERT ... ON CONFLICT DO UPDATE — the DO UPDATE` branch takes a row-exclusive lock and follows the same batch-entry ordering.

### Testing
Didn't add any additional tests - The existing integration tests should be sufficient.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules